### PR TITLE
Add initial Travis config file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: rust
+rust: nightly # once we get to 1.2beta use that


### PR DESCRIPTION
This currently targets the Rust nightly build, as lrpar needs some of its
functionality. Once Rust moves to 1.2beta, we should change to using beta and
after that, assuming Travis supports it, to stable.