### PR TITLE
Catch some crashes when partly or wholly empty inputs are used.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -36,8 +36,8 @@ impl YaccParser {
     }
 
     fn parse_declarations(&mut self) {
-        self.parse_ws();
         loop {
+            self.parse_ws();
             if self.lookahead_is("%%") {
                 self.pos += 2;
                 break;
@@ -46,11 +46,10 @@ impl YaccParser {
                 Ok(()) => (),
                 Err(err) => panic!("{}", err)
             }
-            self.parse_ws();
         }
     }
 
-    fn parse_declaration(&mut self) -> Result<(), String>{
+    fn parse_declaration(&mut self) -> Result<(), String> {
         if self.lookahead_is("%token") {
             self.pos += 6;
             loop {
@@ -189,15 +188,18 @@ impl YaccParser {
     }
 
     fn parse_string(&mut self, s: &str) -> Result<(), String> {
-        let slice = &self.src[self.pos..self.pos + s.len()];
-        if slice != s {
-            return Err(format!("Failed parsing string '{}'", s));
+        if self.pos + s.len() <= self.src.len() {
+            let slice = &self.src[self.pos..self.pos + s.len()];
+            if slice == s {
+                self.pos += s.len();
+                return Ok(());
+            }
         }
-        self.pos += s.len();
-        Ok(())
+        return Err(format!("Failed parsing string '{}'", s));
     }
 
     fn lookahead_is(&mut self, s: &str) -> bool {
+        if self.pos + s.len() > self.src.len() { return false; }
         let slice = &self.src[self.pos..self.pos + s.len()];
         slice == s
     }

--- a/tests/test_yaccparser.rs
+++ b/tests/test_yaccparser.rs
@@ -146,3 +146,17 @@ fn test_simple_decl_fail(){
     let src = "%fail x\n%%\nA : a".to_string();
     parse_yacc(&src);
 }
+
+#[test]
+#[should_panic]
+fn test_empty(){
+    let src = "".to_string();
+    parse_yacc(&src);
+}
+
+#[test]
+#[should_panic]
+fn test_incomplete_rule(){
+    let src = "%token   a\n%%\nA".to_string();
+    parse_yacc(&src);
+}


### PR DESCRIPTION
I fear these actually show that the current parsing scheme doesn't quite work. For example, I think the intention is that empty inputs should succeed but the code doesn't allow them. Nevertheless, this pull request fixes some obvious crashes in a minimal way.