### PR TITLE
Unify the error interface to Yacc parsing.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,8 +1,44 @@
 #![feature(append)]
 
+use std::fmt;
+
 pub mod grammar;
-mod yacc;
+pub mod yacc;
 
 pub mod pgen;
-pub use grammar::Grammar;
-pub use self::yacc::{YaccError, YaccErrorKind, parse_yacc};
+pub use grammar::{Grammar, GrammarError};
+pub use self::yacc::{YaccError, YaccErrorKind};
+use self::yacc::parse_yacc;
+
+#[derive(Debug)]
+pub enum FromYaccError {
+    YaccError(YaccError),
+    GrammarError(GrammarError)
+}
+
+impl From<YaccError> for FromYaccError {
+    fn from(err: YaccError) -> FromYaccError {
+        FromYaccError::YaccError(err)
+    }
+}
+
+impl From<GrammarError> for FromYaccError {
+    fn from(err: GrammarError) -> FromYaccError {
+        FromYaccError::GrammarError(err)
+    }
+}
+
+impl fmt::Display for FromYaccError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            FromYaccError::YaccError(ref e) => e.fmt(f),
+            FromYaccError::GrammarError(ref e) => e.fmt(f),
+        }
+    }
+}
+
+pub fn from_yacc(s:&String) -> Result<Grammar, FromYaccError> {
+    let mut grm = try!(parse_yacc(s));
+    if let Some(e) = grm.validate() { return Err(FromYaccError::GrammarError(e)); }
+    Ok(grm)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::fs::File;
 use std::io::{Read, stderr, Write};
 use std::path::Path;
 
-use lrpar::parse_yacc;
+use lrpar::from_yacc;
 
 fn usage(prog: String, msg: &str) {
     let path = Path::new(prog.as_str());
@@ -51,7 +51,7 @@ fn main() {
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
-    match parse_yacc(&s) {
+    match from_yacc(&s) {
         Ok(ast) => println!("{:?}", ast),
         Err(s) => {
             println!("Error: {}", &s);

--- a/tests/test_pgen.rs
+++ b/tests/test_pgen.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 
 extern crate lrpar;
-use lrpar::parse_yacc;
 use lrpar::grammar::{Grammar, Symbol, SymbolType};
 use lrpar::pgen::{calc_firsts, calc_follows, get_firsts_from_symbols};
 use std::collections::{HashMap, HashSet};

--- a/tests/test_yaccparser.rs
+++ b/tests/test_yaccparser.rs
@@ -1,6 +1,7 @@
 extern crate lrpar;
-use lrpar::{parse_yacc, YaccError, YaccErrorKind};
+use lrpar::{YaccError, YaccErrorKind};
 use lrpar::grammar::{Rule, Symbol, SymbolType};
+use lrpar::yacc::parse_yacc;
 
 macro_rules! terminal {
     ($x:expr) => (Symbol::new($x.to_string(), SymbolType::Terminal));


### PR DESCRIPTION
The vague aim here is that one can have multiple input formats which reuse
most kinds of errors.