### PR TITLE
Refactor Symbol to be a single enum rather than a struct and an enum.

### DIFF
--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -5,7 +5,7 @@ use self::regex::Regex;
 
 type YaccResult<T> = Result<T, YaccError>;
 
-use grammar::{Grammar, Symbol, SymbolType};
+use grammar::{Grammar, Symbol};
 
 pub struct YaccParser {
     src: String,
@@ -136,12 +136,12 @@ impl YaccParser {
               || self.lookahead_is("'", i).is_some() {
                 let (j, sym) = try!(self.parse_terminal(i));
                 i = try!(self.parse_ws(j));
-                syms.push(Symbol::new(sym, SymbolType::Terminal));
+                syms.push(Symbol::Terminal(sym));
             }
             else {
                 let (j, sym) = try!(self.parse_name(i));
                 i = j;
-                syms.push(Symbol::new(sym, SymbolType::Nonterminal));
+                syms.push(Symbol::Nonterminal(sym));
             }
             i = try!(self.parse_ws(i));
         }

--- a/tests/test_yaccparser.rs
+++ b/tests/test_yaccparser.rs
@@ -1,28 +1,26 @@
 extern crate lrpar;
 use lrpar::{YaccError, YaccErrorKind};
-use lrpar::grammar::{Rule, Symbol, SymbolType};
+use lrpar::grammar::{Rule, Symbol};
 use lrpar::yacc::parse_yacc;
 
-macro_rules! terminal {
-    ($x:expr) => (Symbol::new($x.to_string(), SymbolType::Terminal));
-}
 macro_rules! nonterminal {
-    ($x:expr) => (Symbol::new($x.to_string(), SymbolType::Nonterminal));
+    ($x:expr) => (Symbol::Nonterminal($x.to_string()));
+}
+
+macro_rules! terminal {
+    ($x:expr) => (Symbol::Terminal($x.to_string()));
 }
 
 #[test]
 fn test_macro() {
-    assert_eq!(Symbol::new("A".to_string(), SymbolType::Terminal), terminal!("A"));
+    assert_eq!(Symbol::Terminal("A".to_string()), terminal!("A"));
 }
 
 #[test]
 fn test_symbol_eq() {
-    assert_eq!(Symbol::new("A".to_string(), SymbolType::Nonterminal),
-      Symbol::new("A".to_string(), SymbolType::Nonterminal));
-    assert!(Symbol::new("A".to_string(), SymbolType::Terminal)
-      != Symbol::new("B".to_string(), SymbolType::Terminal));
-    assert!(Symbol::new("A".to_string(), SymbolType::Terminal)
-      != Symbol::new("A".to_string(), SymbolType::Nonterminal));
+    assert_eq!(nonterminal!("A"), nonterminal!("A"));
+    assert!(nonterminal!("A") != nonterminal!("B"));
+    assert!(nonterminal!("A") != terminal!("A"));
 }
 
 #[test]


### PR DESCRIPTION
This makes various bits of code a little easier (and will make the future "move
to ints" refactoring much easier) and shorter.