### PR TITLE
Be more flexible about what nonterminal and terminal names can be.

### DIFF
--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -89,12 +89,17 @@ impl Grammar {
                 for sym in alt.iter() {
                     match sym {
                         &Symbol::Nonterminal(ref name) => {
-                            if !self.rules.contains_key(name) && !self.tokens.contains(name) {
+                            if !self.rules.contains_key(name) {
                                 return Err(GrammarError{kind: GrammarErrorKind::UnknownRuleRef,
                                     sym: Some(sym.clone())});
                             }
                         }
-                        &Symbol::Terminal(_) => { }
+                        &Symbol::Terminal(ref name) => {
+                            if !self.tokens.contains(name) {
+                                return Err(GrammarError{kind: GrammarErrorKind::UnknownToken,
+                                    sym: Some(sym.clone())});
+                            }
+                        }
                     }
                 }
             }

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -77,7 +77,8 @@ impl Grammar {
     /// Perform basic validation on the grammar, namely:
     ///   1) The start rule references a rule in the grammar
     ///   2) Every nonterminal reference references a rule in the grammar
-    ///   3) Every terminal reference references a declared token
+    ///   3) If a nonterminal does't reference a rule, it might have been
+    ///      defined as a token using '%token'
     /// If the validation succeeds, None is returned.
     pub fn validate(&self) -> Result<(), GrammarError> {
         if !self.rules.contains_key(&self.start) {
@@ -88,17 +89,12 @@ impl Grammar {
                 for sym in alt.iter() {
                     match sym {
                         &Symbol::Nonterminal(ref name) => {
-                            if !self.rules.contains_key(name) {
+                            if !self.rules.contains_key(name) && !self.tokens.contains(name) {
                                 return Err(GrammarError{kind: GrammarErrorKind::UnknownRuleRef,
                                     sym: Some(sym.clone())});
                             }
                         }
-                        &Symbol::Terminal(ref name) => {
-                            if !self.tokens.contains(name) {
-                                return Err(GrammarError{kind: GrammarErrorKind::UnknownToken,
-                                    sym: Some(sym.clone())});
-                            }
-                        }
+                        &Symbol::Terminal(_) => { }
                     }
                 }
             }

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -149,7 +149,7 @@ impl YaccParser {
     }
 
     fn parse_name(&self, i: usize) -> YaccResult<(usize, String)> {
-        let re = Regex::new(r"^[^\t\n\v\f\r :;|]+").unwrap();
+        let re = Regex::new(r"^[a-zA-Z_.][a-zA-Z0-9_.]*").unwrap();
         match re.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0);

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -149,7 +149,7 @@ impl YaccParser {
     }
 
     fn parse_name(&self, i: usize) -> YaccResult<(usize, String)> {
-        let re = Regex::new("^[a-zA-Z_][a-zA-Z0-9_]*").unwrap();
+        let re = Regex::new(r"^[^\t\n\v\f\r :;|]+").unwrap();
         match re.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0);
@@ -160,7 +160,7 @@ impl YaccParser {
     }
 
     fn parse_terminal(&self, i: usize) -> YaccResult<(usize, String)> {
-        let re = Regex::new("^(\"[a-zA-Z_][a-zA-Z0-9_]*\")|('[a-zA-Z_][a-zA-Z0-9_]*')").unwrap();
+        let re = Regex::new("^(\".+?\")|('.+?')").unwrap();
         match re.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0);

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -136,6 +136,7 @@ impl YaccParser {
               || self.lookahead_is("'", i).is_some() {
                 let (j, sym) = try!(self.parse_terminal(i));
                 i = try!(self.parse_ws(j));
+                self.grammar.tokens.insert(sym.clone());
                 syms.push(Symbol::Terminal(sym));
             }
             else {

--- a/tests/test_grammar.rs
+++ b/tests/test_grammar.rs
@@ -1,5 +1,5 @@
 extern crate lrpar;
-use lrpar::grammar::{Grammar, GrammarError, GrammarErrorKind, nonterminal};
+use lrpar::grammar::{Grammar, GrammarError, GrammarErrorKind, nonterminal, terminal};
 
 #[test]
 fn test_empty_grammar(){
@@ -56,4 +56,15 @@ fn test_valid_token_ref(){
     grm.start = "A".to_string();
     grm.add_rule("A".to_string(), vec!(nonterminal("b")));
     assert!(grm.validate().is_ok());
+}
+
+#[test]
+fn test_invalid_nonterminal_forgotten_token(){
+    let mut grm = Grammar::new();
+    grm.start = "A".to_string();
+    grm.add_rule("A".to_string(), vec!(nonterminal("b"), terminal("b")));
+    match grm.validate() {
+        Err(GrammarError{kind: GrammarErrorKind::UnknownRuleRef, ..}) => (),
+        _ => panic!("Validation error")
+    }
 }

--- a/tests/test_grammar.rs
+++ b/tests/test_grammar.rs
@@ -50,7 +50,10 @@ fn test_invalid_nonterminal_ref(){
 }
 
 #[test]
+#[should_panic]
 fn test_valid_token_ref(){
+    // for now we won't support the YACC feature that allows
+    // to redefine nonterminals as tokens by adding them to '%token'
     let mut grm = Grammar::new();
     grm.tokens.insert("b".to_string());
     grm.start = "A".to_string();

--- a/tests/test_grammar.rs
+++ b/tests/test_grammar.rs
@@ -1,5 +1,5 @@
 extern crate lrpar;
-use lrpar::grammar::{Grammar, GrammarError, GrammarErrorKind, nonterminal, terminal};
+use lrpar::grammar::{Grammar, GrammarError, GrammarErrorKind, nonterminal};
 
 #[test]
 fn test_empty_grammar(){
@@ -50,21 +50,10 @@ fn test_invalid_nonterminal_ref(){
 }
 
 #[test]
-fn test_valid_terminal_ref(){
+fn test_valid_token_ref(){
     let mut grm = Grammar::new();
     grm.tokens.insert("b".to_string());
     grm.start = "A".to_string();
-    grm.add_rule("A".to_string(), vec!(terminal("b")));
+    grm.add_rule("A".to_string(), vec!(nonterminal("b")));
     assert!(grm.validate().is_ok());
-}
-
-#[test]
-fn test_invalid_terminal_ref(){
-    let mut grm = Grammar::new();
-    grm.start = "A".to_string();
-    grm.add_rule("A".to_string(), vec!(terminal("b")));
-    match grm.validate() {
-        Err(GrammarError{kind: GrammarErrorKind::UnknownToken, ..}) => (),
-        _ => panic!("Validation error")
-    }
 }

--- a/tests/test_yaccparser.rs
+++ b/tests/test_yaccparser.rs
@@ -162,26 +162,6 @@ fn test_empty() {
 }
 
 #[test]
-fn test_illegal_name() {
-    let src = "%%0:A;".to_string();
-    match parse_yacc(&src) {
-        Ok(_)  => panic!("Illegal name parsed"),
-        Err(YaccError{kind: YaccErrorKind::IllegalName, ..}) => (),
-        Err(_) => panic!("Incorrect error returned")
-    }
-}
-
-#[test]
-fn test_illegal_string() {
-    let src = "%%A:' ';".to_string();
-    match parse_yacc(&src) {
-        Ok(_)  => panic!("Illegal string parsed"),
-        Err(YaccError{kind: YaccErrorKind::IllegalString, ..}) => (),
-        Err(e) => panic!("Incorrect error returned {}", e)
-    }
-}
-
-#[test]
 fn test_incomplete_rule1() {
     let src = "%%A:".to_string();
     match parse_yacc(&src) {

--- a/tests/test_yaccparser.rs
+++ b/tests/test_yaccparser.rs
@@ -148,6 +148,16 @@ fn test_declaration_tokens() {
 }
 
 #[test]
+fn test_auto_add_tokens() {
+    // we don't support the YACC feature that allows to redeclare
+    // nonterminals as tokens using %token. Instead we automatically
+    // add all tokens we find to the %token list
+    let src = "%%\nA : 'a';".to_string();
+    let grm = parse_yacc(&src).unwrap();
+    assert!(grm.has_token("a"));
+}
+
+#[test]
 #[should_panic]
 fn test_simple_decl_fail() {
     let src = "%fail x\n%%\nA : a".to_string();


### PR DESCRIPTION
It's not entirely clear to me if this is exactly what Yacc does, but the
previous rules were definitely too restrictive. This makes porting examples
from other sources quite a bit easier.