### PR TITLE
Only allocate memory if goto actually finds a matching symbol.

### DIFF
--- a/src/lib/pgen.rs
+++ b/src/lib/pgen.rs
@@ -299,13 +299,13 @@ impl Itemset {
                 let item_rc = items[i].borrow();
                 if item_rc.is_none() { continue; }
                 let item = item_rc.as_ref().unwrap();
-                self.ensure_item_allocd(&grm, &newis, i);
-                let mut newitem_rc = newitems[i].borrow_mut();
-                let mut newitem = newitem_rc.as_mut().unwrap();
                 let alt = &grm.alts[i];
                 for dot in 0..alt.len() {
                     if !item.active[dot] { continue; }
                     if sym == alt[dot] {
+                        self.ensure_item_allocd(&grm, &newis, i);
+                        let mut newitem_rc = newitems[i].borrow_mut();
+                        let mut newitem = newitem_rc.as_mut().unwrap();
                         newitem.active.set(dot + 1, true);
                         for j in 0..grm.terms_len {
                             if item.dots[dot * grm.terms_len + j] {

--- a/src/lib/pgen.rs
+++ b/src/lib/pgen.rs
@@ -278,6 +278,10 @@ impl Itemset {
         }
     }
 
+    /// Ensure that memory is allocated for alternative `aidx` in itemset `is`.
+    ///
+    /// If memory is already allocated, this is a no-op. If no memory is yet allocated, it will
+    /// allocate it.
     fn ensure_item_allocd(&self, grm: &Grammar, is: &Itemset, aidx: AIdx) {
         let mut item_rc = is.items[aidx].borrow_mut();
         if item_rc.as_ref().is_none() {


### PR DESCRIPTION
Before we allocated memory as soon as we found an active item, which was
(mostly) completely pointless. This unnecessarily slowed down things.