### PR TITLE
Change the representation of items away from a single bitvec.

### DIFF
--- a/src/lib/pgen.rs
+++ b/src/lib/pgen.rs
@@ -147,7 +147,6 @@ pub struct Itemset {
     pub items: Vec<RefCell<Option<Item>>>
 }
 
-#[derive(Debug, PartialEq)]
 // An Item instance represents all the possible items that derive from a given alternative in a
 // grammar. We know that if a given alternative E has n symbols, it can lead to at most n+1 items.
 // For example, Consider an alternative:
@@ -160,27 +159,16 @@ pub struct Itemset {
 // can only appear once in the lookahead). Knowing this, we can create a very compact fixed-size
 // representation with room for all the possible items that an alternative can lead to.
 //
-// active is a bitfield of length n+1 (where n is the number of symbols in an alternative). If bit
-// i is set, it means that there is an item with a dot at position i. When this is set, the
-// corresponding section of the dots bitvec is then meaningful.
-//
-// dots is a bitfield of length (n + 1)*grm.terms_len i.e. for each dot, it stores a single bit for
-// each terminal in the grammar. Note that, unlike Firsts::bf, we do not need a bit to represent
-// epsilon.
-//
 // Let us assume that our state has the following items:
 //    E : . 'b' S; // Lookahead 'a' and '$'
 //    E : 'b' S .; // Lookahead '$'
-// then active would be set to:
-//   101
-// and (assuming the grammar has terminals '$', 'a', and 'b' only) dots would be something like the
-// following (depending on the order the terminals are stored in grm.terminal_names):
-//   011000001
-// Where "011" corresponds to "E: . 'b' S;", the middle 000 are inactive, and 001 corresponds to
-// "E: 'b' S .;".
+// and the terminals '$' (bit 0), 'a' (bit 1), and 'b' (bit 2) only. 'lookaheads' then lookaheads
+// would then be set to something along the lines of:
+//    [RefCell(Some(BitVec(011))), RefCell(None), RefCell(Some(BitVec(001)))]
+// Where "011" corresponds to "E: . 'b' S;", and 001 corresponds to "E: 'b' S .;".
+#[derive(Debug, PartialEq)]
 pub struct Item {
-    pub active: BitVec,
-    pub dots: BitVec
+    pub lookaheads: Vec<RefCell<Option<BitVec>>>
 }
 
 impl Itemset {
@@ -193,22 +181,34 @@ impl Itemset {
         Itemset {items: items}
     }
 
+    /// Ensure that memory is allocated for dot `dot` in alternative `aidx` in itemset `is`.
+    ///
+    /// If memory is already allocated, this is a no-op. If no memory is yet allocated, it will
+    /// allocate it.
+    fn ensure_lookahead_allocd(&self, grm: &Grammar, is: &Itemset, aidx: AIdx, dot: SIdx) {
+        let mut item_opt = is.items[aidx].borrow_mut();
+        if item_opt.is_none() {
+            let mut las = Vec::with_capacity(grm.alts[aidx].len());
+            for _ in 0..grm.alts[aidx].len() + 1 {
+                las.push(RefCell::new(None));
+            }
+            *item_opt = Some(Item{lookaheads: las});
+        }
+        let mut la_opt = item_opt.as_ref().unwrap().lookaheads[dot].borrow_mut();
+        if la_opt.is_none() {
+            *la_opt = Some(BitVec::from_elem(grm.terms_len, false));
+        }
+    }
+
     /// Add an item for the alternative 'aidx' with the dot set to position 'dot' and with
     /// lookahead set to 'la'.
     pub fn add(&self, grm: &Grammar, aidx: AIdx, dot: SIdx, la: &BitVec) {
-        if la.len() != grm.terms_len {
-            panic!("Passed a bitfield of length {} instead of {}", la.len(), grm.terms_len);
-        }
-        self.ensure_item_allocd(&grm, &self, aidx);
-        let mut item_rc = self.items[aidx].borrow_mut();
-        let mut alt_cl = &mut item_rc.as_mut().unwrap();
-        alt_cl.active.set(dot, true);
-        let dots = &mut alt_cl.dots;
-        for (i, bit) in la.iter().enumerate() {
-            if bit {
-                dots.set(dot * grm.nonterms_len + i, true);
-            }
-        }
+        assert!(la.len() == grm.terms_len);
+        self.ensure_lookahead_allocd(&grm, &self, aidx, dot);
+        let item_opt = self.items[aidx].borrow_mut();
+        let mut la_opt = item_opt.as_ref().unwrap().lookaheads[dot].borrow_mut();
+        debug_assert!(la_opt.as_ref().unwrap().none());
+        la_opt.as_mut().unwrap().union(la);
     }
 
     /// Close over this Itemset.
@@ -216,13 +216,14 @@ impl Itemset {
         let mut new_la = BitVec::from_elem(grm.terms_len, false);
         loop {
             let mut changed = false;
-            for i in 0..self.items.len() {
-                if self.items[i].borrow().is_none() { continue; }
-                // From this point onwards in the for loop, we know that self.items[i] is
-                // definitely allocated and that calling unwrap() on it is safe.
+            for (i, item_rc) in self.items.iter().enumerate() {
+                if item_rc.borrow().is_none() { continue; }
                 let alt = &grm.alts[i];
                 for dot in 0..alt.len() {
-                    if !self.items[i].borrow().as_ref().unwrap().active[dot] { continue; }
+                    {
+                        let item_opt = item_rc.borrow();
+                        if item_opt.as_ref().unwrap().lookaheads[dot].borrow().is_none() { continue; }
+                    }
                     if let Symbol::Nonterminal(nonterm_i) = alt[dot] {
                         new_la.clear();
                         let mut nullabled = false;
@@ -247,49 +248,21 @@ impl Itemset {
                             }
                         }
                         if !nullabled {
-                            let item_rc = self.items[i].borrow();
-                            let dots = &item_rc.as_ref().unwrap().dots;
-                            for l in 0..grm.terms_len {
-                                if dots[dot * grm.terms_len + l] {
-                                    new_la.set(l, true);
-                                }
-                            }
+                            let item_opt = item_rc.borrow();
+                            let la_opt = item_opt.as_ref().unwrap().lookaheads[dot].borrow();
+                            new_la.union(&la_opt.as_ref().unwrap());
                         }
 
                         for alt_i in grm.rules_alts[nonterm_i].iter() {
-                            self.ensure_item_allocd(&grm, &self, *alt_i);
-                            let mut clalt_rc = self.items[*alt_i].borrow_mut();
-                            let mut clalt = clalt_rc.as_mut().unwrap();
-                            if !clalt.active[0] {
-                                clalt.active.set(0, true);
-                                changed = true;
-                            }
-                            for l in 0..grm.terms_len {
-                                if new_la[l] && !clalt.dots[l] {
-                                    clalt.dots.set(l, true);
-                                    changed = true;
-                                }
-                            }
+                            self.ensure_lookahead_allocd(&grm, &self, *alt_i, 0);
+                            let clitem_opt = self.items[*alt_i].borrow_mut();
+                            let mut clla_opt = clitem_opt.as_ref().unwrap().lookaheads[0].borrow_mut();
+                            if clla_opt.as_mut().unwrap().union(&new_la) { changed = true; }
                         }
                     }
                 }
             }
             if !changed { break; }
-        }
-    }
-
-    /// Ensure that memory is allocated for alternative `aidx` in itemset `is`.
-    ///
-    /// If memory is already allocated, this is a no-op. If no memory is yet allocated, it will
-    /// allocate it.
-    fn ensure_item_allocd(&self, grm: &Grammar, is: &Itemset, aidx: AIdx) {
-        let mut item_rc = is.items[aidx].borrow_mut();
-        if item_rc.as_ref().is_none() {
-            let num_syms = grm.alts[aidx].len() + 1;
-            *item_rc = Some(Item {
-                active: BitVec::from_elem(num_syms, false),
-                dots  : BitVec::from_elem(grm.terms_len * num_syms, false)
-            });
         }
     }
 
@@ -299,23 +272,19 @@ impl Itemset {
         {
             let items = &self.items;
             let newitems = &newis.items;
-            for i in 0..items.len() {
-                let item_rc = items[i].borrow();
-                if item_rc.is_none() { continue; }
-                let item = item_rc.as_ref().unwrap();
+            for (i, item_rc) in items.iter().enumerate() {
+                let item_opt = item_rc.borrow();
+                if item_opt.is_none() { continue; }
+                let lookaheads = &item_opt.as_ref().unwrap().lookaheads;
                 let alt = &grm.alts[i];
                 for dot in 0..alt.len() {
-                    if !item.active[dot] { continue; }
+                    let la_rc = lookaheads[dot].borrow();
+                    if la_rc.is_none() { continue; }
                     if sym == alt[dot] {
-                        self.ensure_item_allocd(&grm, &newis, i);
-                        let mut newitem_rc = newitems[i].borrow_mut();
-                        let mut newitem = newitem_rc.as_mut().unwrap();
-                        newitem.active.set(dot + 1, true);
-                        for j in 0..grm.terms_len {
-                            if item.dots[dot * grm.terms_len + j] {
-                                newitem.dots.set((dot + 1) * grm.terms_len + j, true);
-                            }
-                        }
+                        self.ensure_lookahead_allocd(&grm, &newis, i, dot + 1);
+                        let newitem_opt = newitems[i].borrow_mut();
+                        let mut newla_opt = newitem_opt.as_ref().unwrap().lookaheads[dot + 1].borrow_mut();
+                        newla_opt.as_mut().unwrap().union(&la_rc.as_ref().unwrap());
                     }
                 }
             }
@@ -364,7 +333,8 @@ impl StateGraph {
                     let nstate;
                     {
                         let state = &states[state_i] as &Itemset;
-                        if !state.items[i].borrow().as_ref().unwrap().active[dot] {
+                        let item_opt = state.items[i].borrow();
+                        if item_opt.as_ref().unwrap().lookaheads[dot].borrow().is_none() {
                             continue;
                         }
                         // We have an active item. If the symbol at the dot hasn't been seen


### PR DESCRIPTION
Instead of representing all the lookaheads of a set of items as a single
contiguous item, this breaks them up into one bitvec per item. This makes
reasoning about the data-structure a little easier, and also allows us to make
use of BitVec::union in some performance critical corners. It also requires less
memory to be allocated, as dots that aren't active require a single None (rather
than grm.terms_len bits).

On the Python grammar on my machine, this patch uses about 40% less memory and
is a bit over 2x faster.