### PR TITLE
Store nonterminals in (case insensitive) alphabetical order.

### DIFF
--- a/src/lib/pgen.rs
+++ b/src/lib/pgen.rs
@@ -316,7 +316,7 @@ impl StateGraph {
         let state0 = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len, false);
         la.set(grm.end_term, true);
-        state0.add(&grm, grm.start_rule, 0, &la);
+        state0.add(&grm, grm.start_alt, 0, &la);
         state0.close(&grm, &firsts);
         states.push(state0);
 

--- a/tests/test_grammar.rs
+++ b/tests/test_grammar.rs
@@ -8,7 +8,7 @@ fn test_minimal() {
     let ast = parse_yacc(&"%start R %token T %% R: 'T';".to_string()).unwrap();
     let grm = ast_to_grammar(&ast);
 
-    assert_eq!(grm.start_rule, 0);
+    assert_eq!(grm.start_alt, 0);
     grm.nonterminal_off("^");
     grm.nonterminal_off("R");
     grm.terminal_off("$");


### PR DESCRIPTION
This means that all later processing is deterministic, which should make
debugging (and performance analysis!) predictable, as well as ensure that we
don't have nondeterministic test failure (which I had seen previously, albeit
only when I'd made other mistakes).

This also fixes a very subtle bug, where what was called start_rule was
incorrect: it should have been storing the start alternative. Things happened to
work because previously the start rule and start alternative both happened to be
0.