### PR TITLE
Simplify the representation used by moving to sets of items.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,3 +1,5 @@
+#![feature(drain)]
+
 use std::fmt;
 
 pub mod grammar;


### PR DESCRIPTION
In essence, this commit implements a more traditional, mildly optimised
Knuth-ish LR state generator. Itemsets are now HashSets with keys (alternative
offset, dot) mapping to contexts (i.e. lookaheads). This allows us to simplify
the implementation somewhat which is particularly noticeable in the goto()
function.

However, more significantly we are able to get rid of the significant number of
RefCells of the previous version. These appeared necessary because we are often
iterating over a data-structure and modifying it at the same time. However,
because of the quantity of RefCells we were using, we were spending huge amounts
of time in reading/writing the borrowing state. This commit makes use of todo
lists, splitting up iterating over a data-structure (and adding things to a todo
list) from modifying it (putting things from the todo list into the
data-structure). On the Python grammar this leads to a roughly 8.5x speedup.