### PR TITLE
Use standard terminology and expand a few definitions.

### DIFF
--- a/src/lib/grammar_ast.rs
+++ b/src/lib/grammar_ast.rs
@@ -9,7 +9,7 @@ pub struct GrammarAST {
 
 pub struct Rule {
     pub name: String,
-    pub alternatives: Vec<Vec<Symbol>>
+    pub productions: Vec<Vec<Symbol>>
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -98,7 +98,7 @@ impl GrammarAST {
             }
         }
         for rule in self.rules.values() {
-            for alt in rule.alternatives.iter() {
+            for alt in rule.productions.iter() {
                 for sym in alt.iter() {
                     match sym {
                         &Symbol::Nonterminal(ref name) => {
@@ -136,11 +136,11 @@ impl fmt::Debug for GrammarAST {
 
 impl Rule {
     pub fn new(name: String) -> Rule {
-        Rule {name: name, alternatives: vec![]}
+        Rule {name: name, productions: vec![]}
     }
 
     pub fn add_symbols(&mut self, v: Vec<Symbol>) {
-        self.alternatives.push(v);
+        self.productions.push(v);
     }
 }
 
@@ -148,7 +148,7 @@ impl fmt::Display for Rule {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Rule")
            .field("name", &self.name)
-           .field("alternatives", &self.alternatives)
+           .field("productions", &self.productions)
            .finish()
     }
 }
@@ -157,14 +157,14 @@ impl fmt::Debug for Rule {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Rule")
            .field("name", &self.name)
-           .field("alternatives", &self.alternatives)
+           .field("productions", &self.productions)
            .finish()
     }
 }
 
 impl PartialEq for Rule {
     fn eq(&self, other: &Rule) -> bool {
-        self.name == other.name && self.alternatives == other.alternatives
+        self.name == other.name && self.productions == other.productions
     }
 }
 

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -251,7 +251,7 @@ mod test {
     }
 
     #[test]
-    fn test_rule_alternative_simple() {
+    fn test_rule_production_simple() {
         let src = "
             %%
             A : 'a';
@@ -293,7 +293,7 @@ mod test {
     }
 
     #[test]
-    fn test_rule_alternative_verticalbar() {
+    fn test_rule_alternative() {
         let src = "
             %%
             A : 'a' | 'b';


### PR DESCRIPTION
"Rule" is (mostly) used where "nonterminal" was.
"Production" is (mostly) used where "alternative" previously used.

A few types have been renamed accordingly.

The aim is to bring us into line with the general literature so that people
aren't forced to waste time working out what terminology we're using.
There should be no functional change whatsoever.