### PR TITLE
Basic LR parser.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ authors = ["Lukas Diekmann <http://lukasdiekmann.com/>", "Laurence Tratt <http:/
 doc = false
 name = "lrpar"
 
+[lib]
+name = "lrpar"
+path = "src/lib/mod.rs"
+
 [dependencies]
 getopts = "0.2.14"
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
+lrlex = { git = "http://github.com/softdevteam/lrlex" }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,5 @@
+extern crate lrlex;
+extern crate lrtable;
+
+mod parser;
+pub use parser::parse;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -1,0 +1,185 @@
+use lrlex::Lexeme;
+use lrtable::{Action, Grammar, RIdx, StateTable, Symbol};
+
+pub enum Node {
+    Terminal{lexeme: Lexeme},
+    Nonterminal{rule_idx: RIdx, nodes: Vec<Node>}
+}
+
+#[derive(Debug)]
+pub struct ParseError;
+
+impl Node {
+    /// Return a pretty-printed version of this node. In general, you should call this with
+    /// `indent` set to 0.
+    pub fn pp(&self, grm: &Grammar, input: &str, indent: usize) -> String {
+        let mut s = String::new();
+        for _ in 0..indent {
+            s.push_str(" ");
+        }
+        match self {
+            &Node::Terminal{lexeme: Lexeme{tok_id, start, len}} => {
+                s.push_str(&format!("{} {}\n", grm.terminal_names.get(tok_id).unwrap(), &input[start..start + len]));
+            }
+            &Node::Nonterminal{rule_idx, ref nodes} => {
+                s.push_str(&format!("{}\n", grm.nonterminal_names.get(rule_idx).unwrap()));
+                for n in nodes.iter() {
+                    s.push_str(&n.pp(&grm, &input, indent + 1));
+                };
+            }
+        }
+        s
+    }
+}
+
+
+/// Parse the lexemes into a parse tree.
+pub fn parse(grm: &Grammar, stable: &StateTable, lexemes: &Vec<Lexeme>) -> Result<Node, ParseError> {
+    let mut lexemes_iter = lexemes.iter();
+    // Instead of having a single stack, which we'd then have to invent a new struct / tuple for,
+    // it's easiest to split the parse and parse tree stack into two.
+    let mut pstack = vec![0]; // Parse stack
+    let mut tstack: Vec<Node> = Vec::new(); // Parse tree stack
+    let mut la = lexemes_iter.next().unwrap();
+    loop {
+        let st = *pstack.last().unwrap();
+        match stable.actions.get(&(st, Symbol::Terminal(la.tok_id))) {
+            Some(&Action::Reduce(prod_id)) => {
+                let rule_idx = grm.prod_to_rule_idx(prod_id);
+                let pop_idx = pstack.len() - grm.prods.get(prod_id).unwrap().len();
+                let nodes = tstack.drain(pop_idx - 1..).collect::<Vec<Node>>();
+                tstack.push(Node::Nonterminal{rule_idx: rule_idx, nodes: nodes});
+
+                pstack.drain(pop_idx..);
+                let prior = *pstack.last().unwrap();
+                pstack.push(*stable.gotos.get(&(prior, rule_idx)).unwrap());
+            },
+            Some(&Action::Shift(state_id)) => {
+                tstack.push(Node::Terminal{lexeme: *la});
+                la = lexemes_iter.next().unwrap();
+                pstack.push(state_id);
+            },
+            Some(&Action::Accept) => {
+                debug_assert_eq!(la.tok_id, grm.end_term);
+                debug_assert_eq!(tstack.len(), 1);
+                return Ok(tstack.drain(..).nth(0).unwrap());
+            },
+            _ => {
+                return Err(ParseError);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+    use lrlex::{build_lex, do_lex, Lexeme};
+    use lrtable::yacc_to_statetable;
+    use super::*;
+
+    fn check_parse_output(lexs: &str, grms: &str, input: &str, expected: &str) {
+        let (grm, stable) = yacc_to_statetable(grms).unwrap();
+        let mut lexer = build_lex(lexs).unwrap();
+        let mut rule_ids = HashMap::<&str, usize>::new();
+        for (i, n) in grm.terminal_names.iter().enumerate() {
+            rule_ids.insert(&*n, i);
+        }
+        lexer.set_rule_ids(&rule_ids);
+        let mut lexemes = do_lex(&lexer, &input).unwrap();
+        lexemes.push(Lexeme{tok_id: grm.end_term, start: input.len(), len: 0});
+        let pt = parse(&grm, &stable, &lexemes).unwrap();
+        assert_eq!(expected, pt.pp(&grm, &input, 0));
+    }
+
+    #[test]
+    fn simple_parse() {
+        // From p4 of https://www.cs.umd.edu/class/spring2014/cmsc430/lectures/lec07.pdf
+        check_parse_output("%%
+[a-zA-Z_] ID
+[+] PLUS",
+"
+%start E
+%%
+E: T 'PLUS' E
+ | T;
+T: 'ID';
+",
+"a+b",
+"E
+ T
+  ID a
+ PLUS +
+ E
+  T
+   ID b
+");
+    }
+
+    #[test]
+    fn parse_empty_rules() {
+        let lexs = "%%
+[a-zA-Z_] ID";
+        let grms = "%start S
+%%
+S: L;
+L: 'ID'
+ | ;
+";
+        check_parse_output(&lexs, &grms, "",
+"S
+ L
+");
+
+        check_parse_output(&lexs, &grms, "x",
+"S
+ L
+  ID x
+");
+    }
+
+    #[test]
+    fn recursive_parse() {
+        let lexs = "%%
+[+] PLUS
+[*] MULT
+[0-9]+ INT
+";
+        let grms = "%start Expr
+%%
+Expr : Term 'PLUS' Expr | Term;
+Term : Factor 'MULT' Term | Factor;
+Factor : 'INT';";
+
+        check_parse_output(&lexs, &grms, "2+3*4",
+"Expr
+ Term
+  Factor
+   INT 2
+ PLUS +
+ Expr
+  Term
+   Factor
+    INT 3
+   MULT *
+   Term
+    Factor
+     INT 4
+");
+        check_parse_output(&lexs, &grms, "2*3+4",
+"Expr
+ Term
+  Factor
+   INT 2
+  MULT *
+  Term
+   Factor
+    INT 3
+ PLUS +
+ Expr
+  Term
+   Factor
+    INT 4
+");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,22 @@
 #![cfg_attr(test, allow(dead_code))]
 
-extern crate getopts;
-extern crate lrtable;
-
-use getopts::Options;
+use std::collections::HashMap;
 use std::{env, process};
 use std::fs::File;
 use std::io::{Read, stderr, Write};
 use std::path::Path;
 
-use lrtable::from_yacc;
-use lrtable::stategraph::StateGraph;
-use lrtable::statetable::StateTable;
-use lrtable::grammar::ast_to_grammar;
+extern crate getopts;
+use getopts::Options;
+
+extern crate lrlex;
+use lrlex::{build_lex, do_lex, Lexeme};
+
+extern crate lrtable;
+use lrtable::yacc_to_statetable;
+
+extern crate lrpar;
+use lrpar::parse;
 
 fn usage(prog: String, msg: &str) {
     let path = Path::new(prog.as_str());
@@ -21,11 +25,23 @@ fn usage(prog: String, msg: &str) {
         None => "lrpar"
     };
     if msg.len() > 0 {
-        writeln!(&mut stderr(), "{}\nUsage: {} <filename>", msg, leaf).ok();
-    } else {
-        writeln!(&mut stderr(), "Usage: {} <filename>", leaf).ok();
+        writeln!(&mut stderr(), "{}", msg).ok();
     }
+    writeln!(&mut stderr(), "Usage: {} <lexer.l> <parser.y> <input file>", leaf).ok();
     process::exit(1);
+}
+
+fn read_file(path: &str) -> String {
+    let mut f = match File::open(path) {
+        Ok(r) => r,
+        Err(e) => {
+            writeln!(&mut stderr(), "Can't open file {}: {}", path, e).ok();
+            process::exit(1);
+        }
+    };
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+    s
 }
 
 fn main() {
@@ -38,31 +54,40 @@ fn main() {
         Err(f) => { usage(prog, f.to_string().as_str()); return }
     };
 
-    if matches.opt_present("h") || matches.free.len() != 1 {
+    if matches.opt_present("h") || matches.free.len() != 3 {
         usage(prog, "");
         return;
     }
 
-    let p = matches.free[0].clone();
-    let mut f = match File::open(&p) {
-        Ok(r) => r,
-        Err(e) => {
-            writeln!(&mut stderr(), "Can't open file {}: {}", &p, e).ok();
+    let lex_l_path = &matches.free[0];
+    let mut lexer = match build_lex(&read_file(lex_l_path)) {
+        Ok(ast) => ast,
+        Err(s) => {
+            writeln!(&mut stderr(), "{}: {}", &lex_l_path, &s).ok();
             process::exit(1);
         }
     };
-    let mut s = String::new();
-    f.read_to_string(&mut s).unwrap();
 
-    match from_yacc(&s) {
-        Ok(ast) => {
-            let grm = ast_to_grammar(&ast);
-            let sg = StateGraph::new(&grm);
-            StateTable::new(&grm, &sg);
-        },
+    let yacc_y_path = &matches.free[1];
+    let (grm, stable) = match yacc_to_statetable(&read_file(yacc_y_path)) {
+        Ok(x) => x,
         Err(s) => {
-            println!("Error: {}", &s);
+            writeln!(&mut stderr(), "{}: {}", &yacc_y_path, &s).ok();
             process::exit(1);
         }
+    };
+
+    // Sync up the IDs of terminals in the lexer and parser
+    let mut rule_ids = HashMap::<&str, usize>::new();
+    for (i, n) in grm.terminal_names.iter().enumerate() {
+        rule_ids.insert(&*n, i);
     }
+    lexer.set_rule_ids(&rule_ids);
+
+    let input = read_file(&matches.free[2]);
+
+    let mut lexemes = do_lex(&lexer, &input).unwrap();
+    lexemes.push(Lexeme{tok_id: grm.end_term, start: input.len(), len: 0});
+    let pt = parse(&grm, &stable, &lexemes).unwrap();
+    println!("{}", pt.pp(&grm, &input, 0));
 }


### PR DESCRIPTION
This misses off many, many things (e.g. error recovery, any real form of error reporting), and probably has many other limitations, but it is enough to parse real programs against real grammars (e.g. the Java grammar). When run as a binary, it automatically prints out the resulting parse tree to stdout.

In essence, this is enough of a bare bones LR parser to point out some things we need to change going forwards. The good news is that the split into 3 repositories seems to work quite well -- there are no dependencies between lrlex and lrtable at all.