### PR TITLE
Make the pretty printer have linear(ish) performance.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,5 +89,5 @@ fn main() {
     let mut lexemes = do_lex(&lexer, &input).unwrap();
     lexemes.push(Lexeme{tok_id: grm.end_term, start: input.len(), len: 0});
     let pt = parse(&grm, &stable, &lexemes).unwrap();
-    println!("{}", pt.pp(&grm, &input, 0));
+    println!("{}", pt.pp(&grm, &input));
 }


### PR DESCRIPTION
Before it was O(n^2), continually copying the same strings from nested entries.
On a file of tens of thousands of lines, this wouldn't complete within 20
minutes. After the change, it does so in 4 to 5 seconds.