### PR TITLE
Reflect the fact that lrtable's once-usize types are now distinct.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
     let input = read_file(&matches.free[2]);
 
     let mut lexemes = do_lex(&lexer, &input).unwrap();
-    lexemes.push(Lexeme{tok_id: grm.end_term, start: input.len(), len: 0});
+    lexemes.push(Lexeme{tok_id: usize::from(grm.end_term), start: input.len(), len: 0});
     let pt = parse(&grm, &stable, &lexemes).unwrap();
     println!("{}", pt.pp(&grm, &input));
 }


### PR DESCRIPTION
Currently lrpar assumes a little too much knowledge about lrtable's internals, but this is a gradual step towards fixing that. Mustn't be merged until https://github.com/softdevteam/lrtable/pull/53 is merged. Note that, until that point, the tests will fail; we can rekick them once lrtable/53 is merged and check that everything is OK.