### PR TITLE
Expose the parser module externally.

### DIFF
--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -35,5 +35,4 @@
 extern crate lrlex;
 extern crate lrtable;
 
-mod parser;
-pub use parser::parse;
+pub mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ extern crate lrtable;
 use lrtable::{Minimiser, yacc_to_statetable};
 
 extern crate lrpar;
-use lrpar::parse;
+use lrpar::parser::parse;
 
 fn usage(prog: String, msg: &str) {
     let path = Path::new(prog.as_str());


### PR DESCRIPTION
This also allows the Node type to be exposed.