### PR TITLE
Fewer shift repairs

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -184,13 +184,16 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
                 }
 
                 if finisher {
+                    // We can make Corhuelo's algorithm a little nicer by not adding shifts to the
+                    // end of a repair sequence: they're confusing to the user and they'll be
+                    // handled by the normal parser anyway (and done somewhat faster!).
                     let sc = score(&n_repairs);
                     if finished_score.is_none() || sc < finished_score.unwrap() {
                         finished_score = Some(sc);
                         finished.clear();
                         todo.retain(|x| score(&x.2) <= sc);
                     }
-                    finished.push(n_repairs);
+                    finished.push(repairs);
                 } else if new_la_idx > la_idx {
                     let sc = score(&n_repairs);
                     if finished_score.is_none() || sc <= finished_score.unwrap() {
@@ -372,7 +375,7 @@ E : 'N'
         assert_eq!(errs[0].repairs().len(), 3);
         check_repairs(&grm,
                       errs[0].repairs(),
-                      &vec!["Insert \"CLOSE_BRACKET\", Insert \"PLUS\", Shift",
+                      &vec!["Insert \"CLOSE_BRACKET\", Insert \"PLUS\"",
                             "Insert \"CLOSE_BRACKET\", Delete",
                             "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\""]);
 
@@ -381,7 +384,7 @@ E : 'N'
         assert_eq!(errs.len(), 2);
         check_repairs(&grm,
                       errs[0].repairs(),
-                      &vec!["Delete, Shift, Shift, Shift"]);
+                      &vec!["Delete"]);
         check_repairs(&grm,
                       errs[1].repairs(),
                       &vec!["Delete, Delete, Delete, Delete",
@@ -392,8 +395,8 @@ E : 'N'
         assert_eq!(errs.len(), 2);
         check_repairs(&grm,
                       errs[0].repairs(),
-                      &vec!["Insert \"N\", Shift, Shift, Shift",
-                            "Delete, Shift, Shift, Shift"]);
+                      &vec!["Insert \"N\"",
+                            "Delete"]);
         check_repairs(&grm,
                       errs[1].repairs(),
                       &vec!["Insert \"CLOSE_BRACKET\""]);

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -230,7 +230,8 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
                 }
                 ParseRepair::Shift => {
                     let (new_la_idx, n_pstack)
-                        = lr_cactus(parser, None, la_idx, la_idx + PARSE_AT_LEAST, pstack, Some(tstack));
+                        = lr_cactus(parser, None, la_idx, la_idx + 1, pstack, Some(tstack));
+                    assert_eq!(new_la_idx, la_idx + 1);
                     la_idx = new_la_idx;
                     pstack = n_pstack;
                 }

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -190,7 +190,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
                         finished.clear();
                         todo.retain(|x| score(&x.2) <= sc);
                     }
-                    finished.push((n_pstack, new_la_idx, n_repairs));
+                    finished.push(n_repairs);
                 } else if new_la_idx > la_idx {
                     let sc = score(&n_repairs);
                     if finished_score.is_none() || sc <= finished_score.unwrap() {
@@ -202,7 +202,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
     }
 
     let repairs = finished.iter()
-                          .map(|x| { let mut v = x.2.vals().cloned().collect::<Vec<ParseRepair>>();
+                          .map(|x| { let mut v = x.vals().cloned().collect::<Vec<ParseRepair>>();
                                      v.reverse();
                                      v
                            })


### PR DESCRIPTION
This PR gets rid of the ugly "shifts at the end of repairs" thing, and makes a few other small optimisations that this opens up. From a user perspective this moves the reported repairs from this:

```
Error detected at line 56 col 13. Amongst the valid repairs are:
  Insert "EQ", Keep "Logger", Keep ".", Keep "getLogger"
  Insert "SEMICOLON", Keep "Logger", Keep ".", Keep "getLogger"
  Insert "LPAREN", Keep "Logger", Keep ".", Keep "getLogger"
```

to this:

```
Error detected at line 56 col 13. Amongst the valid repairs are:
  Insert "EQ"
  Insert "SEMICOLON"
  Insert "LPAREN"
```

Although the PR is very small, it's probably worth reviewing the commits separately (and in order).