### PR TITLE
Return parse tree on error

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -370,7 +370,17 @@ E : 'N'
 ";
 
         let (grm, pr) = do_parse(&lexs, &grms, "(nn");
-        let errs = pr.unwrap_err();
+        let (pt, errs) = pr.unwrap_err();
+        assert_eq!(pt.pp(&grm, "(nn"),
+"E
+ E
+  OPEN_BRACKET (
+  E
+   N n
+  CLOSE_BRACKET 
+ PLUS 
+ N n
+");
         assert_eq!(errs.len(), 1);
         let err_tok_id = u16::try_from(usize::from(grm.term_idx("N").unwrap())).ok().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
@@ -382,7 +392,7 @@ E : 'N'
                             "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\""]);
 
         let (grm, pr) = do_parse(&lexs, &grms, "n)+n+n+n)");
-        let errs = pr.unwrap_err();
+        let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_repairs(&grm,
                       errs[0].repairs(),
@@ -392,7 +402,7 @@ E : 'N'
                       &vec!["Delete"]);
 
         let (grm, pr) = do_parse(&lexs, &grms, "(((+n)+n+n+n)");
-        let errs = pr.unwrap_err();
+        let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_repairs(&grm,
                       errs[0].repairs(),

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -342,6 +342,7 @@ mod test {
     }
 
     fn check_repairs(grm: &YaccGrammar, repairs: &Vec<Vec<ParseRepair>>, expected: &[&str]) {
+        assert_eq!(repairs.len(), expected.len());
         for i in 0..repairs.len() {
             // First of all check that all the repairs are unique
             for j in i + 1..repairs.len() {
@@ -388,8 +389,7 @@ E : 'N'
                       &vec!["Delete"]);
         check_repairs(&grm,
                       errs[1].repairs(),
-                      &vec!["Delete, Delete, Delete, Delete",
-                            "Delete"]);
+                      &vec!["Delete"]);
 
         let (grm, pr) = do_parse(&lexs, &grms, "(((+n)+n+n+n)");
         let errs = pr.unwrap_err();

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,8 @@ fn main() {
     let lexemes = lexer.lexemes().unwrap();
     match parse::<u16>(&grm, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
-        Err(errs) => {
+        Err((pt, errs)) => {
+            println!("{}", pt.pp(&grm, &input));
             for e in errs {
                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
                 println!("Error detected at line {} col {}. Amongst the valid repairs are:", line, col);


### PR DESCRIPTION
The resulting parse tree is a little odd, because some lexemes have types but no value. So given a simple calculator-esque grammar and the input "(nn" one ends up with trees like this:

```
 E
  E
   OPEN_BRACKET (
   E
    N n
   CLOSE_BRACKET
  PLUS
  N n
```

At first glance that might seem normal, but if the user had input "(n)+n" the parse tree would look like:

```
 E
  E
   OPEN_BRACKET (
   E
    N n
   CLOSE_BRACKET )
  PLUS +
  N n
```

Still, it's up to the user whether they want to use the resulting parse tree. If the only lexemes affected are things where one doesn't care about the value (e.g. CLOSE_BRACKET or PLUS), it may be possible to do useful things with the resulting tree.