### PR TITLE
Implement the KimYi algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 getopts = "0.2.15"
-cactus = "0.1.1"
+cactus = "1.0.0"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ cactus = "1.0.0"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
+pathfinding = "0.2.2"

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -247,7 +247,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
         in_pstack.clear();
         while !pstack.is_empty() {
             let p = pstack.parent().unwrap();
-            in_pstack.push(pstack.take_or_clone_val().unwrap());
+            in_pstack.push(pstack.try_unwrap().unwrap_or_else(|c| c.val().unwrap().clone()));
             pstack = p;
         }
         in_pstack.reverse();

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -88,7 +88,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
             },
             _ => {
                 let num_inserts = repairs.vals()
-                                         .filter(|r| if let ParseRepair::Insert{..} = **r {
+                                         .filter(|r| if let ParseRepair::InsertTerm{..} = **r {
                                                          true
                                                      } else {
                                                          false
@@ -114,7 +114,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
                                                  pstack.clone(), &mut None);
                             if new_la_idx > la_idx {
                                 debug_assert_eq!(new_la_idx, la_idx + 1);
-                                let n_repairs = repairs.child(ParseRepair::Insert{term_idx});
+                                let n_repairs = repairs.child(ParseRepair::InsertTerm{term_idx});
                                 let sc = score(&n_repairs);
                                 if finished_score.is_none() || sc <= finished_score.unwrap() {
                                     todo.push_back((la_idx, n_pstack, n_repairs, sc));
@@ -222,7 +222,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
         let mut pstack = start_cactus_pstack;
         for r in repairs[0].iter() {
             match *r {
-                ParseRepair::Insert{term_idx} => {
+                ParseRepair::InsertTerm{term_idx} => {
                     let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
                     let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
                                                                 .ok()
@@ -259,7 +259,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
 fn score(repairs: &Cactus<ParseRepair>) -> usize {
     repairs.vals()
            .filter(|x| match *x {
-                           &ParseRepair::Insert{..} | &ParseRepair::Delete => true,
+                           &ParseRepair::InsertTerm{..} | &ParseRepair::Delete => true,
                            &ParseRepair::Shift => false
                        })
            .count()
@@ -277,7 +277,7 @@ mod test {
         let mut out = vec![];
         for &r in repairs {
             match r {
-                ParseRepair::Insert{term_idx} =>
+                ParseRepair::InsertTerm{term_idx} =>
                     out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -1,0 +1,742 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::HashSet;
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+
+use cactus::Cactus;
+use cfgrammar::{Grammar, Symbol, TIdx};
+use cfgrammar::yacc::YaccGrammar;
+use lrlex::Lexeme;
+use lrtable::{Action, StateGraph, StIdx};
+use pathfinding::astar;
+
+use parser::{Node, Parser, ParseRepair};
+
+const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
+const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
+
+#[derive(Clone, Debug, Eq)]
+struct PathFNode {
+    pstack: Cactus<StIdx>,
+    la_idx: usize,
+    t: u64,
+    repairs: Cactus<ParseRepair>,
+    cf: u64,
+    cg: u64
+}
+
+impl Hash for PathFNode {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.pstack.hash(state);
+        self.la_idx.hash(state);
+    }
+}
+
+impl PartialEq for PathFNode {
+    fn eq(&self, other: &PathFNode) -> bool {
+        self.pstack == other.pstack && self.repairs == other.repairs && self.la_idx == other.la_idx
+    }
+}
+
+pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                     (parser: &Parser<TokId>, in_la_idx: usize, in_pstack: &mut Vec<StIdx>,
+                      mut tstack: &mut Vec<Node<TokId>>)
+                  -> (usize, Vec<Vec<ParseRepair>>)
+{
+    // This function implements the algorithm from "LR error repair using the A* algorithm" by
+    // Ik-Soon Kim and Kwangkeun Yi
+    //
+    // The basic idea is to define the problem of finding repairs as a graph-walking problem: we
+    // find the shortest route through the graph to a success node using the standard A* algorithm.
+    // Unfortunately, the paper is a hard read: it's sometimes incomplete, often vague, and
+    // frequently contains errors. Notably, the example on p13 is absolutely crucial to
+    // understanding how the algorithm works, but it is so riddled with errors as to be thoroughly
+    // misleading. Fortunately, however, the ideas underlying the paper are worth the effort.
+    //
+    // This function is, I hope, a fairly faithful implementation. The basic idea behind this
+    // implementation is to use the transition rules from Fig 9 (along with the altered version of
+    // R3S presented on p12) as a mechanism for dynamically calculating the neighbours of the
+    // current node under investigation. As the paper suggests, this only finds a single minimal
+    // cost solution to each parser error, so it's highly non-deterministic: sometimes the minimal
+    // cost solution it comes up with is good, and sometimes it isn't. It is, however, pretty fast,
+    // certainly compared to the Corchuelo et al. algorithm. The biggest extension relative to the
+    // paper is that they really only care about finding a repair: they don't seem to care about
+    // reporting that to the user. The repairs thus reference non-terminals in the grammar which,
+    // to most users, are completely incomprehensible. This commit uses cfgrammar's
+    // SentenceGenerator to turn a non-terminal repair into a (possible set) of terminal inserts,
+    // which is infinitely easier to understand. Thus whilst KimYi might say a repair is:
+    //
+    //   InsertNonterm expr
+    //
+    // this commit will say something like:
+    //
+    //  InsertTerm {Var, Identifier}, InsertTerm{+, -, *}, InsertTerm {Var, Identifier}
+
+    let mut start_cactus_pstack = Cactus::new();
+    for st in in_pstack.drain(..) {
+        start_cactus_pstack = start_cactus_pstack.child(st);
+    }
+
+    let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
+    let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
+                               la_idx: in_la_idx,
+                               t: 1,
+                               repairs: Cactus::new(),
+                               cf: 0,
+                               cg: 0};
+    let astar_opt = astar(
+        &start_node,
+        |n| {
+            // Calculate n's neighbours.
+
+            if n.la_idx > in_la_idx + PORTION_THRESHOLD {
+                return vec![];
+            }
+
+            let mut nbrs = HashSet::new();
+            match n.repairs.val() {
+                Some(&ParseRepair::Delete) => {
+                    // We follow Corcheulo et al.'s suggestions and never follow Deletes with
+                    // Inserts.
+                },
+                _ => {
+                    r3is(parser, &dist, &n, &mut nbrs);
+                    r3ir(parser, &n, &mut nbrs);
+                }
+            }
+            r3d(parser, &n, &mut nbrs);
+            r3s_n(parser, &n, &mut nbrs);
+            let v = nbrs.into_iter()
+                        .map(|x| {
+                                let t = x.cf - n.cf;
+                                (x, t)
+                             })
+                        .collect::<Vec<(PathFNode, _)>>();
+            v
+        },
+        |n| n.cg,
+        |n| {
+            // Is n a success node?
+
+            // As presented in both Corchuelo et al. and Kim Yi, one type of success is if N
+            // symbols are parsed in one go. Indeed, without such a check, the search space quickly
+            // becomes too big. There isn't a way of encoding this check in r3s_n, so we check
+            // instead for its result: if the last N ('PARSE_AT_LEAST' in this library) repairs are
+            // shifts, then we've found a success node.
+            if n.repairs.len() > PARSE_AT_LEAST {
+                let mut all_shfts = true;
+                for x in n.repairs.vals().take(PARSE_AT_LEAST) {
+                    if let ParseRepair::Shift = *x {
+                        continue;
+                    }
+                    all_shfts = false;
+                    break;
+                }
+                if all_shfts {
+                    return true;
+                }
+            }
+
+            let (_, la_term) = parser.next_lexeme(None, n.la_idx);
+            match parser.stable.action(*n.pstack.val().unwrap(), la_term) {
+                Some(Action::Accept) => true,
+                _ => false,
+            }
+        });
+
+    if astar_opt.is_none() {
+        return (in_la_idx, vec![]);
+    }
+
+    let full_rprs = collect_repairs(astar_opt.unwrap().0);
+    let smpl_rprs = simplify_repairs(parser, full_rprs);
+    let (la_idx, mut rpr_pstack) = apply_repairs(parser,
+                                                 in_la_idx,
+                                                 start_cactus_pstack,
+                                                 &mut Some(&mut tstack),
+                                                 &smpl_rprs);
+
+    in_pstack.clear();
+    while !rpr_pstack.is_empty() {
+        let p = rpr_pstack.parent().unwrap();
+        in_pstack.push(rpr_pstack.try_unwrap()
+                                 .unwrap_or_else(|c| c.val()
+                                                      .unwrap()
+                                                      .clone()));
+        rpr_pstack = p;
+    }
+    in_pstack.reverse();
+
+    (la_idx, vec![smpl_rprs])
+}
+
+// The following 4 functions implement the operational semantics presented on pages 11 and 12 of
+// the paper.
+
+fn r3is<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+       (parser: &Parser<TokId>, dist: &Dist, n: &PathFNode, nbrs: &mut HashSet<PathFNode>)
+{
+    let top_pstack = *n.pstack.val().unwrap();
+    let (_, la_term) = parser.next_lexeme(None, n.la_idx);
+    if let Symbol::Term(la_term_idx) = la_term {
+        for (&sym, &sym_st_idx) in parser.sgraph.edges(top_pstack).unwrap().iter() {
+            if let Symbol::Term(term_idx) = sym {
+                if term_idx == parser.grm.eof_term_idx() {
+                    continue;
+                }
+
+                if let Some(d) = dist.dist(sym_st_idx, la_term_idx) {
+                    let nn = PathFNode{
+                        pstack: n.pstack.child(sym_st_idx),
+                        la_idx: n.la_idx,
+                        t: n.t + 1,
+                        repairs: n.repairs.child(ParseRepair::InsertTerm{term_idx}),
+                        cf: n.cf + parser.ic(Symbol::Term(term_idx)),
+                        cg: d};
+                    nbrs.insert(nn);
+                }
+            }
+        }
+    }
+}
+
+fn r3ir<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+       (parser: &Parser<TokId>, n: &PathFNode, nbrs: &mut HashSet<PathFNode>)
+{
+    if n.t != 1 {
+        return;
+    }
+
+    let sg = parser.grm.sentence_generator(|x| parser.ic(Symbol::Term(x)));
+    let top_pstack = *n.pstack.val().unwrap();
+    for &(p_idx, sym_off) in parser.sgraph.closed_state(top_pstack).unwrap().items.keys() {
+        let nt_idx = parser.grm.prod_to_nonterm(p_idx);
+        let mut qi_minus_alpha = n.pstack.clone();
+        for _ in 0..usize::from(sym_off) {
+            qi_minus_alpha = qi_minus_alpha.parent().unwrap();
+        }
+
+        if let Some(goto_st_idx) = parser.stable
+                                         .goto(*qi_minus_alpha.val().unwrap(),
+                                               nt_idx) {
+            let mut n_repairs = n.repairs.clone();
+            let mut cost = 0;
+            for sym in parser.grm.prod(p_idx)
+                                 .unwrap()
+                                 .iter()
+                                 .skip(sym_off.into()) {
+                match sym {
+                    &Symbol::Nonterm(nonterm_idx) => {
+                        n_repairs = n_repairs.child(ParseRepair::InsertNonterm{nonterm_idx});
+                        cost += sg.min_sentence_cost(nonterm_idx);
+                    },
+                    &Symbol::Term(term_idx) => {
+                        n_repairs = n_repairs.child(ParseRepair::InsertTerm{term_idx});
+                        cost += parser.ic(*sym);
+                    }
+                }
+            }
+            let nn = PathFNode{
+                pstack: qi_minus_alpha.child(goto_st_idx),
+                la_idx: n.la_idx,
+                t: 1,
+                repairs: n_repairs,
+                cf: n.cf + cost,
+                cg: 0};
+            nbrs.insert(nn);
+        }
+    }
+}
+
+fn r3d<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+      (parser: &Parser<TokId>, n: &PathFNode, nbrs: &mut HashSet<PathFNode>)
+{
+    if n.t != 1 || n.la_idx == parser.lexemes.len() {
+        return;
+    }
+
+    let (_, la_term) = parser.next_lexeme(None, n.la_idx);
+    let nn = PathFNode{pstack: n.pstack.clone(),
+                       la_idx: n.la_idx + 1,
+                       t: 1,
+                       repairs: n.repairs.child(ParseRepair::Delete),
+                       cf: n.cf + parser.dc(la_term),
+                       cg: 0};
+    nbrs.insert(nn);
+}
+
+// Note that we implement R3S-n (on page 12), *not* R3S (on page 11), since the latter rule clearly
+// doesn't work properly in the context of the overall algorithm.
+
+fn r3s_n<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+      (parser: &Parser<TokId>, n: &PathFNode, nbrs: &mut HashSet<PathFNode>)
+{
+    let (new_la_idx, n_pstack) = parser.lr_cactus(None,
+                                                  n.la_idx,
+                                                  n.la_idx + 1,
+                                                  n.pstack.clone(),
+                                                  &mut None);
+    if new_la_idx == n.la_idx + 1 {
+        let nn = PathFNode{
+            pstack: n_pstack,
+            la_idx: new_la_idx,
+            t: 1,
+            repairs: n.repairs.child(ParseRepair::Shift),
+            cf: n.cf,
+            cg: 0};
+        nbrs.insert(nn);
+    }
+}
+
+/// Convert the output from `astar` into something more usable.
+fn collect_repairs(mut rprs: Vec<PathFNode>) -> Vec<ParseRepair>
+{
+    let mut y = rprs.pop()
+                    .unwrap()
+                    .repairs
+                    .vals()
+                    .cloned()
+                    .collect::<Vec<ParseRepair>>();
+    y.reverse();
+    y
+}
+
+/// Take a vector of parse repairs and return a simplified version. Note that the caller must make
+/// no assumptions about the size or contents of the output: this function might delete, expand, or
+/// do other things to repairs.
+fn simplify_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                   (parser: &Parser<TokId>,
+                    mut rprs: Vec<ParseRepair>)
+                 -> Vec<ParseRepair>
+{
+    // Remove shifts from the end of repairs
+    let sg = parser.grm.sentence_generator(|x| parser.ic(Symbol::Term(x)));
+    while rprs.len() > 0 {
+        if let ParseRepair::Shift = rprs[rprs.len() - 1] {
+            rprs.pop();
+        } else {
+            break;
+        }
+    }
+
+    // Remove all inserts of nonterms which have a minimal sentence cost of 0.
+    let mut j = 0;
+    while j < rprs.len() {
+        if let ParseRepair::InsertNonterm{nonterm_idx} = rprs[j] {
+            if sg.min_sentence_cost(nonterm_idx) == 0 {
+                rprs.remove(j);
+            } else {
+                j += 1;
+            }
+        } else {
+            j += 1;
+        }
+    }
+
+    rprs
+}
+
+/// Apply the `repairs` to `pstack` starting at position `la_idx`: return the resulting parse
+/// distance and a new pstack.
+fn apply_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                (parser: &Parser<TokId>,
+                 mut la_idx: usize,
+                 mut pstack: Cactus<StIdx>,
+                 tstack: &mut Option<&mut Vec<Node<TokId>>>,
+                 repairs: &Vec<ParseRepair>)
+              -> (usize, Cactus<StIdx>)
+{
+    let sg = parser.grm.sentence_generator(|x| parser.ic(Symbol::Term(x)));
+    for r in repairs.iter() {
+        match *r {
+            ParseRepair::InsertNonterm{nonterm_idx} => {
+                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                for t_idx in sg.min_sentence(nonterm_idx) {
+                    let new_lexeme = Lexeme::new(TokId::try_from(usize::from(t_idx))
+                                                                .ok()
+                                                                .unwrap(),
+                                                 next_lexeme.start(), 0);
+                    pstack = parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
+                                              pstack, tstack).1;
+                }
+            }
+            ParseRepair::InsertTerm{term_idx} => {
+                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
+                                                            .ok()
+                                                            .unwrap(),
+                                             next_lexeme.start(), 0);
+                pstack = parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
+                                          pstack, tstack).1;
+            },
+            ParseRepair::Delete => {
+                la_idx += 1;
+            }
+            ParseRepair::Shift => {
+                let (new_la_idx, n_pstack) = parser.lr_cactus(None,
+                                                              la_idx,
+                                                              la_idx + 1,
+                                                              pstack,
+                                                              tstack);
+                assert_eq!(new_la_idx, la_idx + 1);
+                la_idx = new_la_idx;
+                pstack = n_pstack;
+            }
+        }
+    }
+    (la_idx, pstack)
+}
+
+struct Dist {
+    terms_len: usize,
+    table: Vec<u64>
+}
+
+impl Dist {
+    fn new<F>(grm: &YaccGrammar, sgraph: &StateGraph, term_cost: F) -> Dist
+              where F: Fn(TIdx) -> u64
+    {
+        // This is a very simple, and not very efficient, implementation of dist: one could,
+        // for example, cache results of already-seen states.
+
+        let terms_len = grm.terms_len();
+        let states_len = sgraph.all_states_len();
+        let sengen = grm.sentence_generator(&term_cost);
+        let mut table = Vec::new();
+        table.resize(states_len * terms_len, u64::max_value());
+        loop {
+            let mut chgd = false; // Has anything changed?
+            for i in 0..states_len {
+                let edges = sgraph.edges(StIdx::from(i)).unwrap();
+                for (&sym, &sym_st_idx) in edges.iter() {
+                    let d = match sym {
+                        Symbol::Nonterm(nt_idx) => sengen.min_sentence_cost(nt_idx),
+                        Symbol::Term(t_idx) => {
+                            let off = usize::from(i) * terms_len + usize::from(t_idx);
+                            if table[off] != 0 {
+                                table[off] = 0;
+                                chgd = true;
+                            }
+                            term_cost(t_idx)
+                        }
+                    };
+
+                    for j in 0..terms_len {
+                        let this_off = usize::from(i) * terms_len + usize::from(j);
+                        let other_off = usize::from(sym_st_idx) * terms_len + usize::from(j);
+                        if table[other_off] != u64::max_value()
+                           && table[other_off] + d < table[this_off]
+                        {
+                            table[this_off] = table[other_off] + d;
+                            chgd = true;
+                        }
+                    }
+                }
+            }
+            if !chgd {
+                break;
+            }
+        }
+
+        Dist{terms_len, table}
+    }
+
+    pub(crate) fn dist(&self, st_idx: StIdx, t_idx: TIdx) -> Option<u64> {
+        let e = self.table[usize::from(st_idx) * self.terms_len + usize::from(t_idx)];
+        if e == u64::max_value() {
+            None
+        } else {
+            Some(e as u64)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use cfgrammar::Symbol;
+    use cfgrammar::yacc::{yacc_grm, YaccKind};
+    use lrlex::Lexeme;
+    use lrtable::{Minimiser, from_yacc, StIdx};
+
+    use parser::{ParseRepair, RecoveryKind};
+    use parser::test::do_parse;
+    use super::*;
+
+    fn pp_repairs(grm: &YaccGrammar, repairs: &Vec<ParseRepair>) -> String {
+        let mut out = vec![];
+        for &r in repairs {
+            match r {
+                ParseRepair::InsertNonterm{nonterm_idx} =>
+                    out.push(format!("InsertNonterm \"{}\"", grm.nonterm_name(nonterm_idx).unwrap())),
+                ParseRepair::InsertTerm{term_idx} =>
+                    out.push(format!("InsertTerm \"{}\"", grm.term_name(term_idx).unwrap())),
+                ParseRepair::Delete =>
+                    out.push(format!("Delete")),
+                ParseRepair::Shift =>
+                    out.push(format!("Shift"))
+            }
+        }
+        out.join(", ")
+    }
+
+    fn check_repairs(grm: &YaccGrammar, repairs: &Vec<Vec<ParseRepair>>, expected: &[&str]) {
+        for i in 0..repairs.len() {
+            // First of all check that all the repairs are unique
+            for j in i + 1..repairs.len() {
+                assert_ne!(repairs[i], repairs[j]);
+            }
+            if expected.iter().find(|x| **x == pp_repairs(&grm, &repairs[i])).is_none() {
+                panic!("No match found for:\n  {}", pp_repairs(&grm, &repairs[i]));
+            }
+        }
+    }
+
+    #[test]
+    fn corchuelo_example() {
+        // The example from the Corchuelo paper
+        let lexs = "%%
+[(] OPEN_BRACKET
+[)] CLOSE_BRACKET
+[+] PLUS
+n N
+";
+        let grms = "%start E
+%%
+E : 'N'
+  | E 'PLUS' 'N'
+  | 'OPEN_BRACKET' E 'CLOSE_BRACKET'
+  ;
+";
+
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "(nn");
+        let (pt, errs) = pr.unwrap_err();
+        let pp = pt.pp(&grm, "(nn");
+        if !vec![
+"E
+ OPEN_BRACKET (
+ E
+  E
+   N n
+  PLUS 
+  N n
+ CLOSE_BRACKET 
+",
+"E
+ OPEN_BRACKET (
+ E
+  N n
+ CLOSE_BRACKET 
+",
+"E
+ E
+  OPEN_BRACKET (
+  E
+   N n
+  CLOSE_BRACKET 
+ PLUS 
+ N n
+"]
+            .iter()
+            .any(|x| *x == pp) {
+            panic!("Can't find a match for {}", pp);
+        }
+
+        assert_eq!(errs.len(), 1);
+        let err_tok_id = u16::try_from(usize::from(grm.term_idx("N").unwrap())).ok().unwrap();
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
+        check_repairs(&grm,
+                      errs[0].repairs(),
+                      &vec!["InsertTerm \"CLOSE_BRACKET\", InsertTerm \"PLUS\"",
+                            "InsertTerm \"CLOSE_BRACKET\", Delete",
+                            "InsertTerm \"PLUS\", Shift, InsertTerm \"CLOSE_BRACKET\""]);
+
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "n)+n+n+n)");
+        let (_, errs) = pr.unwrap_err();
+        assert_eq!(errs.len(), 2);
+        check_repairs(&grm,
+                      errs[0].repairs(),
+                      &vec!["Delete"]);
+        check_repairs(&grm,
+                      errs[1].repairs(),
+                      &vec!["Delete"]);
+
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "(((+n)+n+n+n)");
+        let (_, errs) = pr.unwrap_err();
+        assert_eq!(errs.len(), 2);
+        check_repairs(&grm,
+                      errs[0].repairs(),
+                      &vec!["InsertTerm \"N\"",
+                            "Delete"]);
+        check_repairs(&grm,
+                      errs[1].repairs(),
+                      &vec!["InsertTerm \"CLOSE_BRACKET\""]);
+    }
+
+    #[test]
+    fn kimyi_example() {
+        // The example from the Corchuelo paper
+        let lexs = "%%
+[(] OPEN_BRACKET
+[)] CLOSE_BRACKET
+a A
+b B
+";
+        let grms = "%start E
+%%
+E: 'OPEN_BRACKET' E 'CLOSE_BRACKET'
+ | 'A'
+ | 'B' ;
+";
+
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "((");
+        let (pt, errs) = pr.unwrap_err();
+        let pp = pt.pp(&grm, "((");
+        if !vec![
+"E
+ OPEN_BRACKET (
+ E
+  OPEN_BRACKET (
+  E
+   A 
+  CLOSE_BRACKET 
+ CLOSE_BRACKET 
+",
+"E
+ OPEN_BRACKET (
+ E
+  OPEN_BRACKET (
+  E
+   B 
+  CLOSE_BRACKET 
+ CLOSE_BRACKET 
+"]
+            .iter()
+            .any(|x| *x == pp) {
+            panic!("Can't find a match for {}", pp);
+        }
+        assert_eq!(errs.len(), 1);
+        let err_tok_id = u16::try_from(usize::from(grm.eof_term_idx())).ok().unwrap();
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
+        assert_eq!(errs[0].repairs().len(), 1);
+        check_repairs(&grm,
+                      errs[0].repairs(),
+                      &vec!["InsertTerm \"A\", InsertTerm \"CLOSE_BRACKET\", InsertTerm \"CLOSE_BRACKET\"",
+                            "InsertTerm \"B\", InsertTerm \"CLOSE_BRACKET\", InsertTerm \"CLOSE_BRACKET\""]);
+    }
+
+    #[test]
+    fn dist_kimyi() {
+        let grms = "%start A
+%%
+A: '(' A ')'
+ | 'a'
+ | 'b'
+ ;
+";
+
+        let grm = yacc_grm(YaccKind::Original, grms).unwrap();
+        let (sgraph, _) = from_yacc(&grm, Minimiser::Pager).unwrap();
+        let d = Dist::new(&grm, &sgraph, |_| 1);
+        let s0 = StIdx::from(0);
+        assert_eq!(d.dist(s0, grm.term_idx("(").unwrap()), Some(0));
+        assert_eq!(d.dist(s0, grm.term_idx(")").unwrap()), Some(2));
+        assert_eq!(d.dist(s0, grm.term_idx("a").unwrap()), Some(0));
+        assert_eq!(d.dist(s0, grm.term_idx("b").unwrap()), Some(0));
+
+        let s5 = sgraph.edge(s0, Symbol::Term(grm.term_idx("(").unwrap())).unwrap();
+        assert_eq!(d.dist(s5, grm.term_idx("(").unwrap()), Some(0));
+        assert_eq!(d.dist(s5, grm.term_idx(")").unwrap()), Some(1));
+        assert_eq!(d.dist(s5, grm.term_idx("a").unwrap()), Some(0));
+        assert_eq!(d.dist(s5, grm.term_idx("b").unwrap()), Some(0));
+
+        let s6 = sgraph.edge(s5, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap();
+        assert_eq!(d.dist(s6, grm.term_idx("(").unwrap()), None);
+        assert_eq!(d.dist(s6, grm.term_idx(")").unwrap()), Some(0));
+        assert_eq!(d.dist(s6, grm.term_idx("a").unwrap()), None);
+        assert_eq!(d.dist(s6, grm.term_idx("b").unwrap()), None);
+    }
+
+    #[test]
+    fn dist_large() {
+        let grms = "%start Expr
+%%
+Expr: Term '+' Expr
+    | Term ;
+
+Term: Factor '*' Term
+    | Factor ;
+
+Factor: '(' Expr ')'
+      | 'INT' ;
+";
+
+        let grm = yacc_grm(YaccKind::Original, grms).unwrap();
+        let (sgraph, _) = from_yacc(&grm, Minimiser::Pager).unwrap();
+        let d = Dist::new(&grm, &sgraph, |_| 1);
+
+        // This only tests a subset of all the states and distances but, I believe, it tests all
+        // more interesting edge cases that the example from the Kim/Yi paper.
+
+        let s0 = StIdx::from(0);
+        assert_eq!(d.dist(s0, grm.term_idx("+").unwrap()), Some(1));
+        assert_eq!(d.dist(s0, grm.term_idx("*").unwrap()), Some(1));
+        assert_eq!(d.dist(s0, grm.term_idx("(").unwrap()), Some(0));
+        assert_eq!(d.dist(s0, grm.term_idx(")").unwrap()), Some(2));
+        assert_eq!(d.dist(s0, grm.term_idx("INT").unwrap()), Some(0));
+
+        let s1 = sgraph.edge(s0, Symbol::Term(grm.term_idx("(").unwrap())).unwrap();
+        assert_eq!(d.dist(s1, grm.term_idx("+").unwrap()), Some(1));
+        assert_eq!(d.dist(s1, grm.term_idx("*").unwrap()), Some(1));
+        assert_eq!(d.dist(s1, grm.term_idx("(").unwrap()), Some(0));
+        assert_eq!(d.dist(s1, grm.term_idx(")").unwrap()), Some(1));
+        assert_eq!(d.dist(s1, grm.term_idx("INT").unwrap()), Some(0));
+
+        let s2 = sgraph.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())).unwrap();
+        assert_eq!(d.dist(s2, grm.term_idx("+").unwrap()), Some(3));
+        assert_eq!(d.dist(s2, grm.term_idx("*").unwrap()), Some(0));
+        assert_eq!(d.dist(s2, grm.term_idx("(").unwrap()), Some(1));
+        assert_eq!(d.dist(s2, grm.term_idx(")").unwrap()), Some(3));
+        assert_eq!(d.dist(s2, grm.term_idx("INT").unwrap()), Some(1));
+
+        let s3 = sgraph.edge(s0, Symbol::Term(grm.term_idx("INT").unwrap())).unwrap();
+        assert_eq!(d.dist(s3, grm.term_idx("+").unwrap()), None);
+        assert_eq!(d.dist(s3, grm.term_idx("*").unwrap()), None);
+        assert_eq!(d.dist(s3, grm.term_idx("(").unwrap()), None);
+        assert_eq!(d.dist(s3, grm.term_idx(")").unwrap()), None);
+        assert_eq!(d.dist(s3, grm.term_idx("INT").unwrap()), None);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -36,7 +36,9 @@ extern crate cactus;
 extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrtable;
+extern crate pathfinding;
 
 mod corchuelo;
 pub mod parser;
-pub use parser::ParseRepair;
+pub use parser::{ParseRepair, RecoveryKind};
+mod kimyi;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -260,7 +260,7 @@ pub fn parse<TokId: Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usize>>
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ParseRepair {
     /// Insert a `Symbol::Term` with idx `term_idx`.
-    Insert{term_idx: TIdx},
+    InsertTerm{term_idx: TIdx},
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -32,6 +32,7 @@
 
 use std::convert::{TryFrom, TryInto};
 
+use cactus::Cactus;
 use cfgrammar::{NTIdx, Symbol, TIdx};
 use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
@@ -184,6 +185,64 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
 
             (la_lexeme, Symbol::Term(TIdx::from(self.grm.eof_term_idx())))
         }
+    }
+
+    /// Start parsing text at `la_idx` (using the lexeme in `lexeme_prefix`, if it is not `None`,
+    /// as the first lexeme) up to (but excluding) `end_la_idx`. If an error is encountered, parsing
+    /// immediately terminates (without recovery).
+    ///
+    /// Note that if `lexeme_prefix` is specified, `la_idx` will still be incremented, and thus
+    /// `end_la_idx` *must* be set to `la_idx + 1` in order that the parser doesn't skip the real
+    /// lexeme at position `la_idx`.
+    pub(crate) fn lr_cactus(&self,
+                            lexeme_prefix: Option<Lexeme<TokId>>,
+                            mut la_idx: usize,
+                            end_la_idx: usize,
+                            mut pstack: Cactus<StIdx>,
+                            tstack: &mut Option<&mut Vec<Node<TokId>>>)
+      -> (usize, Cactus<StIdx>)
+    {
+        assert!(lexeme_prefix.is_none() || end_la_idx == la_idx + 1);
+        while la_idx != end_la_idx {
+            let st = *pstack.val().unwrap();
+            let (la_lexeme, la_term) = self.next_lexeme(lexeme_prefix, la_idx);
+
+            match self.stable.action(st, la_term) {
+                Some(Action::Reduce(prod_id)) => {
+                    let nonterm_idx = self.grm.prod_to_nonterm(prod_id);
+                    let pop_num = self.grm.prod(prod_id).unwrap().len();
+                    if let &mut Some(ref mut tstack_uw) = tstack {
+                        let nodes = tstack_uw.drain(pstack.len() - pop_num - 1..)
+                                             .collect::<Vec<Node<TokId>>>();
+                        tstack_uw.push(Node::Nonterm{nonterm_idx: nonterm_idx, nodes: nodes});
+                    }
+
+                    for _ in 0..pop_num {
+                        pstack = pstack.parent().unwrap();
+                    }
+                    let prior = *pstack.val().unwrap();
+                    pstack = pstack.child(self.stable.goto(prior, NTIdx::from(nonterm_idx)).unwrap());
+                },
+                Some(Action::Shift(state_id)) => {
+                    if let &mut Some(ref mut tstack_uw) = tstack {
+                        tstack_uw.push(Node::Term{lexeme: la_lexeme});
+                    }
+                    pstack = pstack.child(state_id);
+                    la_idx += 1;
+                },
+                Some(Action::Accept) => {
+                    debug_assert_eq!(la_term, Symbol::Term(TIdx::from(self.grm.eof_term_idx())));
+                    if let &mut Some(ref mut tstack_uw) = tstack {
+                        debug_assert_eq!(tstack_uw.len(), 1);
+                    }
+                    break;
+                },
+                None => {
+                    break;
+                }
+            }
+        }
+        (la_idx, pstack)
     }
 }
 

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -38,6 +38,7 @@ use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
 use lrtable::{Action, StateGraph, StateTable, StIdx};
 
+use kimyi;
 use corchuelo;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -80,18 +81,29 @@ pub(crate) type TStack<TokId> = Vec<Node<TokId>>; // Parse tree stack
 pub(crate) type Errors<TokId> = Vec<ParseError<TokId>>;
 
 pub(crate) struct Parser<'a, TokId: Clone + Copy + TryFrom<usize> + TryInto<usize>> where TokId: 'a {
+    pub rcvry_kind: RecoveryKind,
     pub grm: &'a YaccGrammar,
+    pub ic: &'a Fn(TIdx) -> u64,
+    pub dc: &'a Fn(TIdx) -> u64,
     pub sgraph: &'a StateGraph,
     pub stable: &'a StateTable,
-    pub lexemes: &'a Lexemes<TokId>
+    pub lexemes: &'a Lexemes<TokId>,
 }
 
 use std::fmt::Debug;
 impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usize>> Parser<'a, TokId> {
-    fn parse(grm: &YaccGrammar, sgraph: &StateGraph, stable: &StateTable, lexemes: &Lexemes<TokId>)
-         -> Result<Node<TokId>, (Node<TokId>, Vec<ParseError<TokId>>)>
+    fn parse<F, G>(rcvry_kind: RecoveryKind,
+             grm: &YaccGrammar,
+             ic: F,
+             dc: G,
+             sgraph: &StateGraph,
+             stable: &StateTable,
+             lexemes: &Lexemes<TokId>)
+          -> Result<Node<TokId>, (Node<TokId>, Vec<ParseError<TokId>>)>
+      where F: Fn(TIdx) -> u64,
+            G: Fn(TIdx) -> u64
     {
-        let psr = Parser{grm, sgraph, stable, lexemes};
+        let psr = Parser{rcvry_kind, grm, ic: &ic, dc: &dc, sgraph, stable, lexemes};
         let mut pstack = vec![StIdx::from(0)];
         let mut tstack: Vec<Node<TokId>> = Vec::new();
         let mut errors: Vec<ParseError<TokId>> = Vec::new();
@@ -143,7 +155,12 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                     break;
                 },
                 None => {
-                    let (new_la_idx, repairs) = corchuelo::recover(self, la_idx, pstack, tstack);
+                    let (new_la_idx, repairs) = match self.rcvry_kind {
+                        RecoveryKind::Corchuelo =>
+                            corchuelo::recover(self, la_idx, pstack, tstack),
+                        RecoveryKind::KimYi =>
+                            kimyi::recover(self, la_idx, pstack, tstack)
+                    };
                     let keep_going = repairs.len() != 0;
                     errors.push(ParseError{state_idx: st, lexeme_idx: la_idx,
                                            lexeme: la_lexeme, repairs: repairs});
@@ -186,6 +203,20 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
             (la_lexeme, Symbol::Term(TIdx::from(self.grm.eof_term_idx())))
         }
     }
+
+    /// What is the deletion cost of `sym`?
+    pub(crate) fn dc(&self, sym: Symbol) -> u64 {
+        match sym {
+            Symbol::Term(t_idx) => (self.dc)(t_idx),
+            _ => panic!("Internal error")
+        }
+    }
+
+    /// What is the insertion cost of `sym`?
+    pub(crate) fn ic(&self, _: Symbol) -> u64 {
+        1
+    }
+
 
     /// Start parsing text at `la_idx` (using the lexeme in `lexeme_prefix`, if it is not `None`,
     /// as the first lexeme) up to (but excluding) `end_la_idx`. If an error is encountered, parsing
@@ -246,21 +277,45 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
     }
 }
 
+pub enum RecoveryKind {
+    Corchuelo,
+    KimYi
+}
+
 /// Parse the lexemes, returning either a parse tree or a vector of `ParseError`s.
 pub fn parse<TokId: Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usize>>
-            (grm: &YaccGrammar, sgraph: &StateGraph, stable: &StateTable,
-             lexemes: &Vec<Lexeme<TokId>>)
-         -> Result<Node<TokId>, (Node<TokId>, Vec<ParseError<TokId>>)>
+       (grm: &YaccGrammar, sgraph: &StateGraph, stable: &StateTable,
+        lexemes: &Vec<Lexeme<TokId>>)
+    -> Result<Node<TokId>, (Node<TokId>, Vec<ParseError<TokId>>)>
 {
-    Parser::parse(grm, sgraph, stable, lexemes)
+    parse_rcvry(RecoveryKind::KimYi, grm, |_| 1, |_| 1, sgraph, stable, lexemes)
+}
+
+/// Parse the lexemes, specifying a particularly type of error recovery, returning either a parse
+/// tree or a vector of `ParseError`s.
+pub fn parse_rcvry
+       <TokId: Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usize>, F, G>
+       (rcvry_kind: RecoveryKind,
+        grm: &YaccGrammar,
+        ic: F,
+        dc: G,
+        sgraph: &StateGraph,
+        stable: &StateTable,
+        lexemes: &Vec<Lexeme<TokId>>)
+    -> Result<Node<TokId>, (Node<TokId>, Vec<ParseError<TokId>>)>
+    where F: Fn(TIdx) -> u64, G: Fn(TIdx) -> u64
+{
+    Parser::parse(rcvry_kind, grm, ic, dc, sgraph, stable, lexemes)
 }
 
 /// After a parse error is encountered, the parser attempts to find a way of recovering. Each entry
 /// in the sequence of repairs is represented by a `ParseRepair`.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum ParseRepair {
     /// Insert a `Symbol::Term` with idx `term_idx`.
     InsertTerm{term_idx: TIdx},
+    /// Insert a `Symbol::Nonterm` with idx `nonterm_idx`.
+    InsertNonterm{nonterm_idx: NTIdx},
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.
@@ -307,7 +362,9 @@ pub(crate) mod test {
     use lrtable::{Minimiser, from_yacc};
     use super::*;
 
-    pub(crate) fn do_parse(lexs: &str, grms: &str, input: &str) -> (YaccGrammar, Result<Node<u16>, (Node<u16>, Vec<ParseError<u16>>)>) {
+    pub(crate) fn do_parse(rcvry_kind: RecoveryKind, lexs: &str, grms: &str, input: &str)
+                       -> (YaccGrammar, Result<Node<u16>, (Node<u16>, Vec<ParseError<u16>>)>)
+    {
         let mut lexerdef = build_lex(lexs).unwrap();
         let grm = yacc_grm(YaccKind::Original, grms).unwrap();
         let (sgraph, stable) = from_yacc(&grm, Minimiser::Pager).unwrap();
@@ -318,12 +375,12 @@ pub(crate) mod test {
             lexerdef.set_rule_ids(&rule_ids);
         }
         let lexemes = lexerdef.lexer(&input).lexemes().unwrap();
-        let pr = parse(&grm, &sgraph, &stable, &lexemes);
+        let pr = parse_rcvry(rcvry_kind, &grm, |_| 1, |_| 1, &sgraph, &stable, &lexemes);
         (grm, pr)
     }
 
     fn check_parse_output(lexs: &str, grms: &str, input: &str, expected: &str) {
-        let (grm, pt) = do_parse(lexs, grms, input);
+        let (grm, pt) = do_parse(RecoveryKind::KimYi, lexs, grms, input);
         assert_eq!(expected, pt.unwrap().pp(&grm, &input));
     }
 
@@ -436,13 +493,13 @@ Call: 'ID' 'OPEN_BRACKET' 'CLOSE_BRACKET';";
  CLOSE_BRACKET )
 ");
 
-        let (grm, pr) = do_parse(&lexs, &grms, "f(");
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "f(");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 1);
         let err_tok_id = u16::try_from(usize::from(grm.eof_term_idx())).ok().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
 
-        let (grm, pr) = do_parse(&lexs, &grms, "f(f(");
+        let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "f(f(");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 1);
         let err_tok_id = u16::try_from(usize::from(grm.term_idx("ID").unwrap())).ok().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ extern crate lrtable;
 use lrtable::{Minimiser, from_yacc};
 
 extern crate lrpar;
-use lrpar::parser::{parse, ParseRepair};
+use lrpar::parser::{parse_rcvry, ParseRepair, RecoveryKind};
 
 fn usage(prog: &str, msg: &str) -> ! {
     let path = Path::new(prog);
@@ -167,10 +167,13 @@ fn main() {
     let input = read_file(&matches.free[2]);
     let lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
-    match parse::<u16>(&grm, &sgraph, &stable, &lexemes) {
+    let ic = |_| 1; // Cost of inserting a terminal
+    let dc = |_| 1; // Cost of deleting a terminal
+    match parse_rcvry::<u16, _, _>(RecoveryKind::KimYi, &grm, &ic, dc, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((pt, errs)) => {
             println!("{}", pt.pp(&grm, &input));
+            let sg = grm.sentence_generator(&ic);
             for e in errs {
                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
                 println!("Error detected at line {} col {}. Amongst the valid repairs are:", line, col);
@@ -178,17 +181,36 @@ fn main() {
                     let mut lex_idx = e.lexeme_idx();
                     let mut out = vec![];
                     for &r in repair {
-                        if let ParseRepair::InsertTerm{term_idx} = r {
-                            out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap()));
-                        } else {
-                            let l = lexemes[lex_idx];
-                            let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
-                            if let ParseRepair::Delete = r {
-                                out.push(format!("Delete \"{}\"", t));
-                            } else {
-                                out.push(format!("Keep \"{}\"", t));
+                        match r {
+                            ParseRepair::InsertNonterm{nonterm_idx} => {
+                                let mut s = String::new();
+                                s.push_str("Insert {");
+                                for (i, snt) in sg.min_sentences(nonterm_idx).iter().enumerate() {
+                                    if i > 0 {
+                                        s.push_str(", ");
+                                    }
+                                    for (j, t_idx) in snt.iter().enumerate() {
+                                        if j > 0 {
+                                            s.push_str(" ");
+                                        }
+                                        s.push_str(grm.term_name(*t_idx).unwrap());
+                                    }
+                                }
+                                s.push_str("}");
+                                out.push(s);
+                            },
+                            ParseRepair::InsertTerm{term_idx} =>
+                                out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
+                            ParseRepair::Delete | ParseRepair::Shift => {
+                                let l = lexemes[lex_idx];
+                                let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
+                                if let ParseRepair::Delete = r {
+                                    out.push(format!("Delete \"{}\"", t));
+                                } else {
+                                    out.push(format!("Keep \"{}\"", t));
+                                }
+                                lex_idx += 1;
                             }
-                            lex_idx += 1;
                         }
                     }
                     println!("  {}", out.join(", "));

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
             process::exit(1);
         }
     };
-    let (_, stable) = match from_yacc(&grm, Minimiser::Pager) {
+    let (sgraph, stable) = match from_yacc(&grm, Minimiser::Pager) {
         Ok(x) => x,
         Err(s) => {
             writeln!(&mut stderr(), "{}: {}", &yacc_y_path, &s).ok();
@@ -167,7 +167,7 @@ fn main() {
     let input = read_file(&matches.free[2]);
     let lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
-    match parse::<u16>(&grm, &stable, &lexemes) {
+    match parse::<u16>(&grm, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((pt, errs)) => {
             println!("{}", pt.pp(&grm, &input));

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,7 +178,7 @@ fn main() {
                     let mut lex_idx = e.lexeme_idx();
                     let mut out = vec![];
                     for &r in repair {
-                        if let ParseRepair::Insert{term_idx} = r {
+                        if let ParseRepair::InsertTerm{term_idx} = r {
                             out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap()));
                         } else {
                             let l = lexemes[lex_idx];


### PR DESCRIPTION
The first 4 commits mostly just move code around semi-mechanically: the final commit is where the action lies. It is quite big, unfortunately, but it's really difficult to split it into smaller bits.

After playing with this for weeks, I think I've understood the paper well enough to derive a fairly faithful implementation (bearing in mind that the paper is somewhat incomplete, and frequently confusing). As the paper suggests, this only finds a single minimal cost solution to each parser error, so it's highly non-deterministic: sometimes the minimal cost solution it comes up with is good, and sometimes it isn't. It is, however, pretty fast, certainly compared to the Corchuelo et al. algorithm. The biggest extension relative to the paper is that they really only care about finding a repair: they don't seem to care about reporting that to the user. The repairs thus reference non-terminals in the grammar which, to most users, are completely incomprehensible. This commit uses cfgrammar's SentenceGenerator to turn a non-terminal repair into a (possible set) of terminal inserts, which is infinitely easier to understand. Thus whilst KimYi might say a repair is:

```
  InsertNonterm expr
```

this commit will say something like:

```
  InsertTerm {Var, Identifier}, InsertTerm{+, -, *}, InsertTerm {Var, Identifier}
```

There are several glaring inefficiencies in this commit: notably, we continually make new SentenceGenerators. That's because, currently, we don't really have a good way for passing state between, and within, error recovery instances. However, that's a more invasive change which can come later.

To test this on a real Java file use something like:

```
$ cargo run --release java.l java.y <java file with errors in>
```

which will print the parse tree and then repairs e.g.:

```
Error detected at line 56 col 13. Amongst the valid repairs are:
  Insert "EQ"
Error detected at line 56 col 62. Amongst the valid repairs are:
  Insert {INTEGER_LITERAL, FLOATING_POINT_LITERAL, BOOLEAN_LITERAL, CHARACTER_LITERAL, STRING_LITERAL, NULL_LITERAL, THIS, IDENTIFIER}, Keep ")", Insert "SEMICOLON"
Error detected at line 1137 col 41. Amongst the valid repairs are:
  Insert "AND", Keep "to", Insert "QUESTION"
```

The big difference relative to the Corchuelo et al. algorithm is that you can end up with "choose from a set". e.g. the second repair says "choose any of {integer, float, ..., identifier}".

A future PR will implement what I'm tentatively calling the KimYi+ algorithm, which is basically their algorithm plus various ideas I've collected to make it more useful to humans. That might slightly depend on how https://github.com/samueltardieu/pathfinding/pull/44 ends up going.