### PR TITLE
Update the API to deal with the case where we can't find any repairs.

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -321,7 +321,7 @@ E : 'N'
 
         let (grm, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, "(nn");
         let (pt, errs) = pr.unwrap_err();
-        assert_eq!(pt.pp(&grm, "(nn"),
+        assert_eq!(pt.unwrap().pp(&grm, "(nn"),
 "E
  E
   OPEN_BRACKET (

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -566,8 +566,7 @@ E : 'N'
 
         let (grm, pr) = do_parse(RecoveryKind::KimYiPlus, &lexs, &grms, "(nn");
         let (pt, errs) = pr.unwrap_err();
-        let pp = pt.pp(&grm, "(nn");
-        println!("{}", pp);
+        let pp = pt.unwrap().pp(&grm, "(nn");
         if !vec![
 "E
  OPEN_BRACKET (
@@ -649,7 +648,7 @@ E: 'OPEN_BRACKET' E 'CLOSE_BRACKET'
 
         let (grm, pr) = do_parse(RecoveryKind::KimYi, &lexs, &grms, "((");
         let (pt, errs) = pr.unwrap_err();
-        let pp = pt.pp(&grm, "((");
+        let pp = pt.unwrap().pp(&grm, "((");
         if !vec![
 "E
  OPEN_BRACKET (

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -358,7 +358,7 @@ E : 'N'
 
         let (grm, pr) = do_parse(RecoveryKind::KimYiPlus, &lexs, &grms, "(nn");
         let (pt, errs) = pr.unwrap_err();
-        let pp = pt.pp(&grm, "(nn");
+        let pp = pt.unwrap().pp(&grm, "(nn");
         if !vec![
 "E
  OPEN_BRACKET (
@@ -433,7 +433,7 @@ E: 'OPEN_BRACKET' E 'CLOSE_BRACKET'
 
         let (grm, pr) = do_parse(RecoveryKind::KimYiPlus, &lexs, &grms, "((");
         let (pt, errs) = pr.unwrap_err();
-        let pp = pt.pp(&grm, "((");
+        let pp = pt.unwrap().pp(&grm, "((");
         if !vec![
 "E
  OPEN_BRACKET (

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,8 +171,11 @@ fn main() {
     let dc = |_| 1; // Cost of deleting a terminal
     match parse_rcvry::<u16, _, _>(RecoveryKind::KimYiPlus, &grm, &ic, dc, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
-        Err((pt, errs)) => {
-            println!("{}", pt.pp(&grm, &input));
+        Err((o_pt, errs)) => {
+            match o_pt {
+                Some(pt) => println!("{}", pt.pp(&grm, &input)),
+                None     => println!("Unable to repair input sufficiently to produce parse tree.\n")
+            }
             let sg = grm.sentence_generator(&ic);
             for e in errs {
                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();


### PR DESCRIPTION
Some errors are so bad that we can't find suitable repairs, at which point it's impossible to return a parse tree (it would, at best, be only a partial tree). It therefore seems safest to say that, when an error occurs, the user may, or may not, get back a parse tree too.

This might require a tweak to Diffract, although given that I don't *think* it does anything with the `Err` clause yet, it might not.