### PR TITLE
Allow the different recovery algorithms to have state

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -39,15 +39,26 @@ use cfgrammar::Symbol;
 use lrlex::Lexeme;
 use lrtable::{Action, StIdx};
 
-use parser::{Node, Parser, ParseRepair};
+use parser::{Node, Parser, ParseRepair, Recoverer};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 const INSERT_THRESHOLD: usize = 4; // N_i in Corchuelo et al.
 const DELETE_THRESHOLD: usize = 3; // N_d in Corchuelo et al.
 
-pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
-                     (parser: &Parser<TokId>, in_la_idx: usize, in_pstack: &mut Vec<StIdx>,
+pub(crate) struct Corchuelo;
+
+pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                       ()
+                     -> Box<Recoverer<TokId>> {
+    Box::new(Corchuelo)
+}
+
+impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId> for Corchuelo {
+fn recover           (&self,
+                      parser: &Parser<TokId>,
+                      in_la_idx: usize,
+                      in_pstack: &mut Vec<StIdx>,
                       tstack: &mut Vec<Node<TokId>>)
                   -> (usize, Vec<Vec<ParseRepair>>)
 {
@@ -255,6 +266,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
     }
 
     (la_idx, repairs)
+}
 }
 
 fn score(repairs: &Cactus<ParseRepair>) -> usize {

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -54,219 +54,228 @@ pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<u
     Box::new(Corchuelo)
 }
 
-impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId> for Corchuelo {
-fn recover           (&self,
-                      parser: &Parser<TokId>,
-                      in_la_idx: usize,
-                      in_pstack: &mut Vec<StIdx>,
-                      tstack: &mut Vec<Node<TokId>>)
-                  -> (usize, Vec<Vec<ParseRepair>>)
+impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId>
+                                                                                for Corchuelo
 {
-    // This function implements the algorithm from "Repairing syntax errors in LR parsers" by
-    // Rafael Corchuelo, Jose A. Perez, Antonio Ruiz, and Miguel Toro.
-    //
-    // Because we want to create a parse tree even when error recovery has happened, we can be a
-    // bit clever. In our first stage, we try and find repair sequences using a cactus stack to
-    // represent the parse stack, but we don't try and create/alter the parse tree. Once we've
-    // found valid repairs, we select one arbitrarily (as do Corchuelo) and then replay it, this
-    // time turning on parse tree creation/alteration. Thus we only pay the costs of creating the
-    // parse tree for the one parse that we need it. This has a vaguely similar flavour to part of
-    // the ALL(*) algorithm (where, when the LL parser gets to a point of ambiguity, it fires up
-    // non-LL sub-parsers, which then tell the LL parser which path it should take).
+    fn recover(&self,
+               parser: &Parser<TokId>,
+               in_la_idx: usize,
+               in_pstack: &mut Vec<StIdx>,
+               tstack: &mut Vec<Node<TokId>>)
+           -> (usize, Vec<Vec<ParseRepair>>)
+    {
+        // This function implements the algorithm from "Repairing syntax errors in LR parsers" by
+        // Rafael Corchuelo, Jose A. Perez, Antonio Ruiz, and Miguel Toro.
+        //
+        // Because we want to create a parse tree even when error recovery has happened, we can be
+        // a bit clever. In our first stage, we try and find repair sequences using a cactus stack
+        // to represent the parse stack, but we don't try and create/alter the parse tree. Once
+        // we've found valid repairs, we select one arbitrarily (as do Corchuelo) and then replay
+        // it, this time turning on parse tree creation/alteration. Thus we only pay the costs of
+        // creating the parse tree for the one parse that we need it. This has a vaguely similar
+        // flavour to part of the ALL(*) algorithm (where, when the LL parser gets to a point of
+        // ambiguity, it fires up non-LL sub-parsers, which then tell the LL parser which path it
+        // should take).
 
-    let mut cactus_pstack = Cactus::new();
-    for st in in_pstack.drain(..) {
-        cactus_pstack = cactus_pstack.child(st);
-    }
-    let start_cactus_pstack = cactus_pstack.clone();
+        let mut cactus_pstack = Cactus::new();
+        for st in in_pstack.drain(..) {
+            cactus_pstack = cactus_pstack.child(st);
+        }
+        let start_cactus_pstack = cactus_pstack.clone();
 
-    let mut todo = VecDeque::new();
-    todo.push_back((in_la_idx, cactus_pstack, Cactus::new(), 0));
-    let mut finished = vec![];
-    let mut finished_score: Option<usize> = None;
-    while todo.len() > 0 {
-        let cur = todo.pop_front().unwrap();
-        let la_idx = cur.0;
-        let pstack = cur.1;
-        let repairs: Cactus<ParseRepair> = cur.2;
+        let mut todo = VecDeque::new();
+        todo.push_back((in_la_idx, cactus_pstack, Cactus::new(), 0));
+        let mut finished = vec![];
+        let mut finished_score: Option<usize> = None;
+        while todo.len() > 0 {
+            let cur = todo.pop_front().unwrap();
+            let la_idx = cur.0;
+            let pstack = cur.1;
+            let repairs: Cactus<ParseRepair> = cur.2;
 
-        // Insertion rule (ER1)
-        match repairs.val() {
-            Some(&ParseRepair::Delete) => {
-                // In order to avoid adding both [Del, Ins x] and [Ins x, Del] (which are
-                // equivalent), we follow Corcheulo et al.'s suggestion and never add an Ins after
-                // a Del.
-            },
-            _ => {
-                let num_inserts = repairs.vals()
-                                         .filter(|r| if let ParseRepair::InsertTerm{..} = **r {
-                                                         true
-                                                     } else {
-                                                         false
-                                                     })
-                                         .count();
-                if num_inserts <= INSERT_THRESHOLD {
-                    for sym in parser.stable.state_actions(*pstack.val().unwrap()) {
-                        if let Symbol::Term(term_idx) = sym {
-                            if term_idx == parser.grm.eof_term_idx() {
-                                continue;
-                            }
+            // Insertion rule (ER1)
+            match repairs.val() {
+                Some(&ParseRepair::Delete) => {
+                    // In order to avoid adding both [Del, Ins x] and [Ins x, Del] (which are
+                    // equivalent), we follow Corcheulo et al.'s suggestion and never add an Ins
+                    // after a Del.
+                },
+                _ => {
+                    let num_inserts = repairs.vals()
+                                             .filter(|r| if let ParseRepair::InsertTerm{..} = **r {
+                                                             true
+                                                         } else {
+                                                             false
+                                                         })
+                                             .count();
+                    if num_inserts <= INSERT_THRESHOLD {
+                        for sym in parser.stable.state_actions(*pstack.val().unwrap()) {
+                            if let Symbol::Term(term_idx) = sym {
+                                if term_idx == parser.grm.eof_term_idx() {
+                                    continue;
+                                }
 
-                            // We make the artificially inserted lexeme appear to start at the same
-                            // position as the real next lexeme, but have zero length (so that it's
-                            // clear it's not really something the user created).
-                            let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
-                            let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
-                                                                        .ok()
-                                                                        .unwrap(),
-                                                         next_lexeme.start(), 0);
-                            let (new_la_idx, n_pstack) =
-                                parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
-                                                 pstack.clone(), &mut None);
-                            if new_la_idx > la_idx {
-                                debug_assert_eq!(new_la_idx, la_idx + 1);
-                                let n_repairs = repairs.child(ParseRepair::InsertTerm{term_idx});
-                                let sc = score(&n_repairs);
-                                if finished_score.is_none() || sc <= finished_score.unwrap() {
-                                    todo.push_back((la_idx, n_pstack, n_repairs, sc));
+                                // We make the artificially inserted lexeme appear to start at the
+                                // same position as the real next lexeme, but have zero length (so
+                                // that it's clear it's not really something the user created).
+                                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                                let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
+                                                                            .ok()
+                                                                            .unwrap(),
+                                                             next_lexeme.start(), 0);
+                                let (new_la_idx, n_pstack) =
+                                    parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
+                                                     pstack.clone(), &mut None);
+                                if new_la_idx > la_idx {
+                                    debug_assert_eq!(new_la_idx, la_idx + 1);
+                                    let n_repairs =
+                                        repairs.child(ParseRepair::InsertTerm{term_idx});
+                                    let sc = score(&n_repairs);
+                                    if finished_score.is_none() || sc <= finished_score.unwrap() {
+                                        todo.push_back((la_idx, n_pstack, n_repairs, sc));
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
 
-        // Delete rule (ER2)
-        if la_idx < parser.lexemes.len() {
-            let num_deletes = repairs.vals()
-                                     .filter(|r| if let ParseRepair::Delete = **r {
-                                                     true
-                                                 } else {
-                                                     false
-                                                 })
-                                     .count();
-            if num_deletes <= DELETE_THRESHOLD {
-                let n_repairs = repairs.child(ParseRepair::Delete);
-                let sc = score(&n_repairs);
-                if finished_score.is_none() || sc <= finished_score.unwrap() {
-                    todo.push_back((la_idx + 1, pstack.clone(), n_repairs, sc));
+            // Delete rule (ER2)
+            if la_idx < parser.lexemes.len() {
+                let num_deletes = repairs.vals()
+                                         .filter(|r| if let ParseRepair::Delete = **r {
+                                                         true
+                                                     } else {
+                                                         false
+                                                     })
+                                         .count();
+                if num_deletes <= DELETE_THRESHOLD {
+                    let n_repairs = repairs.child(ParseRepair::Delete);
+                    let sc = score(&n_repairs);
+                    if finished_score.is_none() || sc <= finished_score.unwrap() {
+                        todo.push_back((la_idx + 1, pstack.clone(), n_repairs, sc));
+                    }
+                }
+            }
+
+            // Forward move rule (ER3)
+            //
+            // Note the rule in Corchuelo et al. is confusing and, I think, wrong. It reads:
+            //   (S, I) \rightarrow_{LR*} (S', I') \wedge (j = N \vee 0 < j < N
+            //                                             \wedge f(q_r, t_{j + 1} \in {accept, error})
+            // First I think the bracketing would be clearer if written as:
+            //   j = N \vee (0 < j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
+            // And I think the condition should be:
+            //   j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
+            // because there's no reason that any symbols need to be shifted in order for an accept
+            // (or, indeed an error) state to be reached.
+            //
+            // So the full rule should I think be:
+            //   (S, I) \rightarrow_{LR*} (S', I')
+            //   \wedge (j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error}))
+            {
+                let (new_la_idx, n_pstack)
+                    = parser.lr_cactus(None,
+                                       la_idx,
+                                       la_idx + PARSE_AT_LEAST,
+                                       pstack.clone(),
+                                       &mut None);
+                if new_la_idx < in_la_idx + PORTION_THRESHOLD {
+                    // A repair is a "finisher" (i.e. can be considered complete and doesn't need
+                    // to be added to the todo list) if it's parsed at least N symbols or parsing
+                    // ends in an Accept action.
+                    let mut finisher = false;
+                    if new_la_idx == la_idx + PARSE_AT_LEAST {
+                        finisher = true;
+                    } else {
+                        debug_assert!(new_la_idx < la_idx + PARSE_AT_LEAST);
+                        let st = *n_pstack.val().unwrap();
+                        let (_, la_term) = parser.next_lexeme(None, new_la_idx);
+                        match parser.stable.action(st, la_term) {
+                            Some(Action::Accept) => finisher = true,
+                            None => (),
+                            _ => continue,
+                        }
+                    }
+
+                    // As described, at this point we should add (new_la_idx - la_idx) Shifts to
+                    // the repair sequence. However, there's no point in doing this if they're
+                    // added to a finisher: Shifts at the end of a repair sequence confuse users
+                    // and slow down parsing. We thus only add Shifts if this is a non-finisher.
+
+                    let sc = score(&repairs); // Since Shifts don't count to the score, this isn't
+                                              // affected by the presence or absence of finisher
+                                              // Shifts.
+                    if finisher {
+                        if finished_score.is_none() || sc < finished_score.unwrap() {
+                            finished_score = Some(sc);
+                            finished.clear();
+                            todo.retain(|x| score(&x.2) <= sc);
+                        }
+                        finished.push(repairs);
+                    } else if new_la_idx > la_idx &&
+                              (finished_score.is_none() || sc <= finished_score.unwrap()) {
+                        let mut n_repairs = repairs.clone();
+                        debug_assert_eq!(score(&repairs), score(&n_repairs));
+                        for _ in la_idx..new_la_idx {
+                            n_repairs = n_repairs.child(ParseRepair::Shift);
+                        }
+                        todo.push_back((new_la_idx, n_pstack, n_repairs, sc));
+                    }
                 }
             }
         }
 
-        // Forward move rule (ER3)
-        //
-        // Note the rule in Corchuelo et al. is confusing and, I think, wrong. It reads:
-        //   (S, I) \rightarrow_{LR*} (S', I') \wedge (j = N \vee 0 < j < N
-        //                                             \wedge f(q_r, t_{j + 1} \in {accept, error})
-        // First I think the bracketing would be clearer if written as:
-        //   j = N \vee (0 < j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
-        // And I think the condition should be:
-        //   j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error})
-        // because there's no reason that any symbols need to be shifted in order for an accept
-        // (or, indeed an error) state to be reached.
-        //
-        // So the full rule should I think be:
-        //   (S, I) \rightarrow_{LR*} (S', I')
-        //   \wedge (j = N \vee (0 <= j < N \wedge f(q_r, t_{j + 1} \in {accept, error}))
+        let repairs = finished.iter()
+                              .map(|x| { let mut v = x.vals().cloned().collect::<Vec<ParseRepair>>();
+                                         v.reverse();
+                                         v
+                               })
+                              .collect::<Vec<Vec<ParseRepair>>>();
+
+        // Arbitrarily select one of the repairs and replay it against the original starting
+        // pstack, this time also creating a parse tree.
+
+        let mut la_idx = in_la_idx;
         {
-            let (new_la_idx, n_pstack)
-                = parser.lr_cactus(None, la_idx, la_idx + PARSE_AT_LEAST, pstack.clone(), &mut None);
-            if new_la_idx < in_la_idx + PORTION_THRESHOLD {
-                // A repair is a "finisher" (i.e. can be considered complete and doesn't need to be
-                // added to the todo list) if it's parsed at least N symbols or parsing ends in
-                // an Accept action.
-                let mut finisher = false;
-                if new_la_idx == la_idx + PARSE_AT_LEAST {
-                    finisher = true;
-                } else {
-                    debug_assert!(new_la_idx < la_idx + PARSE_AT_LEAST);
-                    let st = *n_pstack.val().unwrap();
-                    let (_, la_term) = parser.next_lexeme(None, new_la_idx);
-                    match parser.stable.action(st, la_term) {
-                        Some(Action::Accept) => finisher = true,
-                        None => (),
-                        _ => continue,
+            let mut pstack = start_cactus_pstack;
+            for r in repairs[0].iter() {
+                match *r {
+                    ParseRepair::InsertNonterm{..} => panic!("Internal error"),
+                    ParseRepair::InsertTerm{term_idx} => {
+                        let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                        let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
+                                                                    .ok()
+                                                                    .unwrap(),
+                                                     next_lexeme.start(), 0);
+                        pstack = parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
+                                                  pstack, &mut Some(tstack)).1;
+                    },
+                    ParseRepair::Delete => {
+                        la_idx += 1;
                     }
-                }
-
-                // As described, at this point we should add (new_la_idx - la_idx) Shifts to the
-                // repair sequence. However, there's no point in doing this if they're added to a
-                // finisher: Shifts at the end of a repair sequence confuse users and slow down
-                // parsing. We thus only add Shifts if this is a non-finisher.
-
-                let sc = score(&repairs); // Since Shifts don't count to the score, this isn't
-                                          // affected by the presence or absence of finisher Shifts.
-                if finisher {
-                    if finished_score.is_none() || sc < finished_score.unwrap() {
-                        finished_score = Some(sc);
-                        finished.clear();
-                        todo.retain(|x| score(&x.2) <= sc);
+                    ParseRepair::Shift => {
+                        let (new_la_idx, n_pstack)
+                            = parser.lr_cactus(None, la_idx, la_idx + 1, pstack, &mut Some(tstack));
+                        assert_eq!(new_la_idx, la_idx + 1);
+                        la_idx = new_la_idx;
+                        pstack = n_pstack;
                     }
-                    finished.push(repairs);
-                } else if new_la_idx > la_idx &&
-                          (finished_score.is_none() || sc <= finished_score.unwrap()) {
-                    let mut n_repairs = repairs.clone();
-                    debug_assert_eq!(score(&repairs), score(&n_repairs));
-                    for _ in la_idx..new_la_idx {
-                        n_repairs = n_repairs.child(ParseRepair::Shift);
-                    }
-                    todo.push_back((new_la_idx, n_pstack, n_repairs, sc));
                 }
             }
-        }
-    }
 
-    let repairs = finished.iter()
-                          .map(|x| { let mut v = x.vals().cloned().collect::<Vec<ParseRepair>>();
-                                     v.reverse();
-                                     v
-                           })
-                          .collect::<Vec<Vec<ParseRepair>>>();
-
-    // Arbitrarily select one of the repairs and replay it against the original starting pstack,
-    // this time also creating a parse tree.
-
-    let mut la_idx = in_la_idx;
-    {
-        let mut pstack = start_cactus_pstack;
-        for r in repairs[0].iter() {
-            match *r {
-                ParseRepair::InsertNonterm{..} => panic!("Internal error"),
-                ParseRepair::InsertTerm{term_idx} => {
-                    let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
-                    let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
-                                                                .ok()
-                                                                .unwrap(),
-                                                 next_lexeme.start(), 0);
-                    pstack = parser.lr_cactus(Some(new_lexeme), la_idx, la_idx + 1,
-                                              pstack, &mut Some(tstack)).1;
-                },
-                ParseRepair::Delete => {
-                    la_idx += 1;
-                }
-                ParseRepair::Shift => {
-                    let (new_la_idx, n_pstack)
-                        = parser.lr_cactus(None, la_idx, la_idx + 1, pstack, &mut Some(tstack));
-                    assert_eq!(new_la_idx, la_idx + 1);
-                    la_idx = new_la_idx;
-                    pstack = n_pstack;
-                }
+            in_pstack.clear();
+            while !pstack.is_empty() {
+                let p = pstack.parent().unwrap();
+                in_pstack.push(pstack.try_unwrap().unwrap_or_else(|c| c.val().unwrap().clone()));
+                pstack = p;
             }
+            in_pstack.reverse();
         }
 
-        in_pstack.clear();
-        while !pstack.is_empty() {
-            let p = pstack.parent().unwrap();
-            in_pstack.push(pstack.try_unwrap().unwrap_or_else(|c| c.val().unwrap().clone()));
-            pstack = p;
-        }
-        in_pstack.reverse();
+        (la_idx, repairs)
     }
-
-    (la_idx, repairs)
-}
 }
 
 fn score(repairs: &Cactus<ParseRepair>) -> usize {

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -72,16 +72,20 @@ impl PartialEq for PathFNode {
     }
 }
 
-pub(crate) struct KimYi;
-
-pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
-                       ()
-                     -> Box<Recoverer<TokId>> {
-    Box::new(KimYi)
+pub(crate) struct KimYi {
+    dist: Dist
 }
 
-impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId>
-                                                                                for KimYi
+pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                       (parser: &Parser<TokId>)
+                     -> Box<Recoverer<TokId>>
+{
+    let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
+    Box::new(KimYi{dist})
+}
+
+impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+     Recoverer<TokId> for KimYi
 {
     fn recover(&self,
                parser: &Parser<TokId>,
@@ -126,7 +130,6 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
             start_cactus_pstack = start_cactus_pstack.child(st);
         }
 
-        let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
         let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
                                    la_idx: in_la_idx,
                                    t: 1,
@@ -149,7 +152,7 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
                         // Inserts.
                     },
                     _ => {
-                        r3is(parser, &dist, &n, &mut nbrs);
+                        r3is(parser, &self.dist, &n, &mut nbrs);
                         r3ir(parser, &n, &mut nbrs);
                     }
                 }

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -47,12 +47,16 @@ const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
 
-pub(crate) struct KimYiPlus;
+pub(crate) struct KimYiPlus {
+    dist: Dist
+}
 
 pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
-                       ()
-                     -> Box<Recoverer<TokId>> {
-    Box::new(KimYiPlus)
+                       (parser: &Parser<TokId>)
+                     -> Box<Recoverer<TokId>>
+{
+    let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
+    Box::new(KimYiPlus{dist})
 }
 
 impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId>
@@ -80,7 +84,6 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
             start_cactus_pstack = start_cactus_pstack.child(st);
         }
 
-        let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
         let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
                                    la_idx: in_la_idx,
                                    t: 1,
@@ -103,7 +106,7 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
                         // Inserts.
                     },
                     _ => {
-                        r3is(parser, &dist, &n, &mut nbrs);
+                        r3is(parser, &self.dist, &n, &mut nbrs);
                         r3ir(parser, &n, &mut nbrs);
                     }
                 }

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -41,14 +41,25 @@ use lrtable::{Action, StIdx};
 use pathfinding::astar_bag;
 
 use kimyi::{apply_repairs, Dist, PathFNode, r3is, r3ir, r3d, r3s_n};
-use parser::{Node, Parser, ParseRepair};
+use parser::{Node, Parser, ParseRepair, Recoverer};
 
 const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
 
-pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
-                     (parser: &Parser<TokId>, in_la_idx: usize, in_pstack: &mut Vec<StIdx>,
+pub(crate) struct KimYiPlus;
+
+pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                       ()
+                     -> Box<Recoverer<TokId>> {
+    Box::new(KimYiPlus)
+}
+
+impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId> for KimYiPlus {
+fn recover           (&self,
+                      parser: &Parser<TokId>,
+                      in_la_idx: usize,
+                      in_pstack: &mut Vec<StIdx>,
                       mut tstack: &mut Vec<Node<TokId>>)
                   -> (usize, Vec<Vec<ParseRepair>>)
 {
@@ -162,6 +173,7 @@ pub(crate) fn recover<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usi
     in_pstack.reverse();
 
     (la_idx, rnk_rprs)
+}
 }
 
 /// Convert the output from `astar_bag` into something more usable.

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -55,125 +55,127 @@ pub(crate) fn recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<u
     Box::new(KimYiPlus)
 }
 
-impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId> for KimYiPlus {
-fn recover           (&self,
-                      parser: &Parser<TokId>,
-                      in_la_idx: usize,
-                      in_pstack: &mut Vec<StIdx>,
-                      mut tstack: &mut Vec<Node<TokId>>)
-                  -> (usize, Vec<Vec<ParseRepair>>)
+impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> Recoverer<TokId>
+                                                                                for KimYiPlus
 {
-    // This function implements an algorithm whose core is based on that from "LR error repair
-    // using the A* algorithm" by Ik-Soon Kim and Kwangkeun Yi. However, we extend it in several
-    // ways.
-    //
-    // The basic idea behind this implementation is to use the transition rules from Fig 9 (along
-    // with the altered version of R3S presented on p12) as a mechanism for dynamically calculating
-    // the neighbours of the current node under investigation. Unlike KimYi, who
-    // non-deterministically return a single repair, this variant evaluates all minimal cost
-    // repairs.
+    fn recover(&self,
+               parser: &Parser<TokId>,
+               in_la_idx: usize,
+               in_pstack: &mut Vec<StIdx>,
+               mut tstack: &mut Vec<Node<TokId>>)
+           -> (usize, Vec<Vec<ParseRepair>>)
+    {
+        // This function implements an algorithm whose core is based on that from "LR error repair
+        // using the A* algorithm" by Ik-Soon Kim and Kwangkeun Yi. However, we extend it in
+        // several ways.
+        //
+        // The basic idea behind this implementation is to use the transition rules from Fig 9
+        // (along with the altered version of R3S presented on p12) as a mechanism for dynamically
+        // calculating the neighbours of the current node under investigation. Unlike KimYi, who
+        // non-deterministically return a single repair, this variant evaluates all minimal cost
+        // repairs.
 
-    let mut start_cactus_pstack = Cactus::new();
-    for st in in_pstack.drain(..) {
-        start_cactus_pstack = start_cactus_pstack.child(st);
-    }
+        let mut start_cactus_pstack = Cactus::new();
+        for st in in_pstack.drain(..) {
+            start_cactus_pstack = start_cactus_pstack.child(st);
+        }
 
-    let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
-    let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
-                               la_idx: in_la_idx,
-                               t: 1,
-                               repairs: Cactus::new(),
-                               cf: 0,
-                               cg: 0};
-    let (astar_cnds, _) = astar_bag(
-        &start_node,
-        |n| {
-            // Calculate n's neighbours.
+        let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
+        let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
+                                   la_idx: in_la_idx,
+                                   t: 1,
+                                   repairs: Cactus::new(),
+                                   cf: 0,
+                                   cg: 0};
+        let (astar_cnds, _) = astar_bag(
+            &start_node,
+            |n| {
+                // Calculate n's neighbours.
 
-            if n.la_idx > in_la_idx + PORTION_THRESHOLD {
-                return vec![];
-            }
-
-            let mut nbrs = HashSet::new();
-            match n.repairs.val() {
-                Some(&ParseRepair::Delete) => {
-                    // We follow Corcheulo et al.'s suggestions and never follow Deletes with
-                    // Inserts.
-                },
-                _ => {
-                    r3is(parser, &dist, &n, &mut nbrs);
-                    r3ir(parser, &n, &mut nbrs);
+                if n.la_idx > in_la_idx + PORTION_THRESHOLD {
+                    return vec![];
                 }
-            }
-            r3d(parser, &n, &mut nbrs);
-            r3s_n(parser, &n, &mut nbrs);
-            let v = nbrs.into_iter()
-                        .map(|x| {
-                                let t = x.cf - n.cf;
-                                (x, t)
-                             })
-                        .collect::<Vec<(PathFNode, _)>>();
-            v
-        },
-        |n| n.cg,
-        |n| {
-            // Is n a success node?
 
-            // As presented in both Corchuelo et al. and Kim Yi, one type of success is if N
-            // symbols are parsed in one go. Indeed, without such a check, the search space quickly
-            // becomes too big. There isn't a way of encoding this check in r3s_n, so we check
-            // instead for its result: if the last N ('PARSE_AT_LEAST' in this library) repairs are
-            // shifts, then we've found a success node.
-            if n.repairs.len() > PARSE_AT_LEAST {
-                let mut all_shfts = true;
-                for x in n.repairs.vals().take(PARSE_AT_LEAST) {
-                    if let ParseRepair::Shift = *x {
-                        continue;
+                let mut nbrs = HashSet::new();
+                match n.repairs.val() {
+                    Some(&ParseRepair::Delete) => {
+                        // We follow Corcheulo et al.'s suggestions and never follow Deletes with
+                        // Inserts.
+                    },
+                    _ => {
+                        r3is(parser, &dist, &n, &mut nbrs);
+                        r3ir(parser, &n, &mut nbrs);
                     }
-                    all_shfts = false;
-                    break;
                 }
-                if all_shfts {
-                    return true;
+                r3d(parser, &n, &mut nbrs);
+                r3s_n(parser, &n, &mut nbrs);
+                let v = nbrs.into_iter()
+                            .map(|x| {
+                                    let t = x.cf - n.cf;
+                                    (x, t)
+                                 })
+                            .collect::<Vec<(PathFNode, _)>>();
+                v
+            },
+            |n| n.cg,
+            |n| {
+                // Is n a success node?
+
+                // As presented in both Corchuelo et al. and Kim Yi, one type of success is if N
+                // symbols are parsed in one go. Indeed, without such a check, the search space
+                // quickly becomes too big. There isn't a way of encoding this check in r3s_n, so
+                // we check instead for its result: if the last N ('PARSE_AT_LEAST' in this
+                // library) repairs are shifts, then we've found a success node.
+                if n.repairs.len() > PARSE_AT_LEAST {
+                    let mut all_shfts = true;
+                    for x in n.repairs.vals().take(PARSE_AT_LEAST) {
+                        if let ParseRepair::Shift = *x {
+                            continue;
+                        }
+                        all_shfts = false;
+                        break;
+                    }
+                    if all_shfts {
+                        return true;
+                    }
                 }
-            }
 
-            let (_, la_term) = parser.next_lexeme(None, n.la_idx);
-            match parser.stable.action(*n.pstack.val().unwrap(), la_term) {
-                Some(Action::Accept) => true,
-                _ => false,
-            }
-        });
+                let (_, la_term) = parser.next_lexeme(None, n.la_idx);
+                match parser.stable.action(*n.pstack.val().unwrap(), la_term) {
+                    Some(Action::Accept) => true,
+                    _ => false,
+                }
+            });
 
-    if astar_cnds.is_empty() {
-        return (in_la_idx, vec![]);
+        if astar_cnds.is_empty() {
+            return (in_la_idx, vec![]);
+        }
+
+        let full_rprs = collect_repairs(astar_cnds);
+        let smpl_rprs = simplify_repairs(parser, full_rprs);
+        let rnk_rprs = rank_cnds(parser,
+                                 in_la_idx,
+                                 start_cactus_pstack.clone(),
+                                 smpl_rprs);
+        let (la_idx, mut rpr_pstack) = apply_repairs(parser,
+                                                     in_la_idx,
+                                                     start_cactus_pstack,
+                                                     &mut Some(&mut tstack),
+                                                     &rnk_rprs[0]);
+
+        in_pstack.clear();
+        while !rpr_pstack.is_empty() {
+            let p = rpr_pstack.parent().unwrap();
+            in_pstack.push(rpr_pstack.try_unwrap()
+                                     .unwrap_or_else(|c| c.val()
+                                                          .unwrap()
+                                                          .clone()));
+            rpr_pstack = p;
+        }
+        in_pstack.reverse();
+
+        (la_idx, rnk_rprs)
     }
-
-    let full_rprs = collect_repairs(astar_cnds);
-    let smpl_rprs = simplify_repairs(parser, full_rprs);
-    let rnk_rprs = rank_cnds(parser,
-                             in_la_idx,
-                             start_cactus_pstack.clone(),
-                             smpl_rprs);
-    let (la_idx, mut rpr_pstack) = apply_repairs(parser,
-                                                 in_la_idx,
-                                                 start_cactus_pstack,
-                                                 &mut Some(&mut tstack),
-                                                 &rnk_rprs[0]);
-
-    in_pstack.clear();
-    while !rpr_pstack.is_empty() {
-        let p = rpr_pstack.parent().unwrap();
-        in_pstack.push(rpr_pstack.try_unwrap()
-                                 .unwrap_or_else(|c| c.val()
-                                                      .unwrap()
-                                                      .clone()));
-        rpr_pstack = p;
-    }
-    in_pstack.reverse();
-
-    (la_idx, rnk_rprs)
-}
 }
 
 /// Convert the output from `astar_bag` into something more usable.

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -165,8 +165,10 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
                                              RecoveryKind::Corchuelo => corchuelo::recoverer(),
-                                             RecoveryKind::KimYi => kimyi::recoverer(),
-                                             RecoveryKind::KimYiPlus => kimyi_plus::recoverer(),
+                                             RecoveryKind::KimYi =>
+                                                 kimyi::recoverer(&self),
+                                             RecoveryKind::KimYiPlus =>
+                                                 kimyi_plus::recoverer(&self),
                                          });
                     }
 


### PR DESCRIPTION
Some of the recoverers (a word I think I've just coined) can use pre-calculated data to speed up their actions. Previously there was no sensible way for them to store this state, so they often calculate it over and over again. This PR first uses trait objects to allow different recoverers to store state, and then uses that facility to cache data. For the KimYi+ algorithm, on one of my standard examples, this reduces running time from ~3.5s to ~1.5s. That said, the speed improvement will heavily depend on the particular input: some examples will see no gains at all. However, I think it unlikely that any examples will slow down, so this is, overall, a win.

Each commit should stand alone, so I'd suggest reviewing each in isolation. [Notably, the 2nd commit -- which is a big part of the overall diff -- is mechanical and you may feel requires only a light review.]