### PR TITLE
Simplify presentation of repairs

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -306,7 +306,7 @@ fn convert_to_parser_repairs(all_rprs: Vec<Vec<Repair>>) -> Vec<Vec<ParseRepair>
                              {
                                   match *y {
                                       Repair::InsertTerm{term_idx} =>
-                                          ParseRepair::InsertTerm{term_idx},
+                                          ParseRepair::InsertTerm(term_idx),
                                       Repair::Delete => ParseRepair::Delete,
                                       Repair::Shift => ParseRepair::Shift,
                                   }
@@ -328,7 +328,7 @@ mod test {
         for r in repairs.iter() {
             match *r {
                 ParseRepair::InsertNonterm{..} => panic!("Internal error"),
-                ParseRepair::InsertTerm{term_idx} =>
+                ParseRepair::InsertTerm(term_idx) =>
                     out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -306,7 +306,7 @@ fn convert_to_parser_repairs(all_rprs: Vec<Vec<Repair>>) -> Vec<Vec<ParseRepair>
                              {
                                   match *y {
                                       Repair::InsertTerm{term_idx} =>
-                                          ParseRepair::InsertTerm(term_idx),
+                                          ParseRepair::Insert(term_idx),
                                       Repair::Delete => ParseRepair::Delete,
                                       Repair::Shift => ParseRepair::Shift,
                                   }
@@ -327,8 +327,8 @@ mod test {
         let mut out = vec![];
         for r in repairs.iter() {
             match *r {
-                ParseRepair::InsertNonterm{..} => panic!("Internal error"),
-                ParseRepair::InsertTerm(term_idx) =>
+                ParseRepair::InsertSeq{..} => panic!("Internal error"),
+                ParseRepair::Insert(term_idx) =>
                     out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
                 ParseRepair::Delete =>
                     out.push(format!("Delete")),

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -325,8 +325,8 @@ mod test {
 
     fn pp_repairs(grm: &YaccGrammar, repairs: &Vec<ParseRepair>) -> String {
         let mut out = vec![];
-        for &r in repairs {
-            match r {
+        for r in repairs.iter() {
+            match *r {
                 ParseRepair::InsertNonterm{..} => panic!("Internal error"),
                 ParseRepair::InsertTerm{term_idx} =>
                     out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -47,7 +47,7 @@ use parser::{Node, Parser, ParseRepair, Recoverer};
 const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Repair {
     /// Insert a `Symbol::Term` with idx `term_idx`.
     InsertTerm{term_idx: TIdx},
@@ -565,9 +565,9 @@ pub(crate) mod test {
 
     pub(crate) fn pp_repairs(grm: &YaccGrammar, repairs: &Vec<ParseRepair>) -> String {
         let mut out = vec![];
-        for &r in repairs {
-            match r {
                 ParseRepair::InsertNonterm{nonterm_idx} =>
+        for r in repairs.iter() {
+            match *r {
                     out.push(format!("InsertNonterm \"{}\"", grm.nonterm_name(nonterm_idx))),
                 ParseRepair::InsertTerm{term_idx} =>
                     out.push(format!("InsertTerm \"{}\"", grm.term_name(term_idx).unwrap())),

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -218,7 +218,7 @@ fn simplify_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize
             let mut rprs = all_rprs.get_mut(i).unwrap();
             let mut j = 0;
             while j < rprs.len() {
-                if let Repair::InsertNonterm{nonterm_idx} = rprs[j] {
+                if let Repair::InsertNonterm(nonterm_idx) = rprs[j] {
                     if sg.min_sentence_cost(nonterm_idx) == 0 {
                         rprs.remove(j);
                     } else {
@@ -263,10 +263,10 @@ fn simplify_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize
             .map(|x| x.iter()
                       .map(|y| {
                                     match *y {
-                                        Repair::InsertTerm{term_idx} =>
-                                            ParseRepair::InsertTerm{term_idx},
-                                        Repair::InsertNonterm{nonterm_idx} =>
-                                            ParseRepair::InsertNonterm{nonterm_idx},
+                                        Repair::InsertTerm(term_idx) =>
+                                            ParseRepair::InsertTerm(term_idx),
+                                        Repair::InsertNonterm(nonterm_idx) =>
+                                            ParseRepair::InsertNonterm(nonterm_idx),
                                         Repair::Delete => ParseRepair::Delete,
                                         Repair::Shift => ParseRepair::Shift,
                                     }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -334,9 +334,9 @@ pub fn parse_rcvry
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParseRepair {
     /// Insert a `Symbol::Term` with idx `term_idx`.
-    InsertTerm{term_idx: TIdx},
+    InsertTerm(TIdx),
     /// Insert a `Symbol::Nonterm` with idx `nonterm_idx`.
-    InsertNonterm{nonterm_idx: NTIdx},
+    InsertNonterm(NTIdx),
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -333,10 +333,10 @@ pub fn parse_rcvry
 /// in the sequence of repairs is represented by a `ParseRepair`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParseRepair {
-    /// Insert a `Symbol::Term` with idx `term_idx`.
-    InsertTerm(TIdx),
-    /// Insert a `Symbol::Nonterm` with idx `nonterm_idx`.
-    InsertNonterm(NTIdx),
+    /// Insert a `Symbol::Term`.
+    Insert(TIdx),
+    /// Insert one of the sequences of `Symbol::Term`s.
+    InsertSeq(Vec<Vec<TIdx>>),
     /// Delete a symbol.
     Delete,
     /// Shift a symbol.

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -291,7 +291,8 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
 }
 
 pub trait Recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> {
-    fn recover(&self, &Parser<TokId>, usize, &mut PStack, &mut TStack<TokId>) -> (usize, Vec<Vec<ParseRepair>>);
+    fn recover(&self, &Parser<TokId>, usize, &mut PStack, &mut TStack<TokId>)
+           -> (usize, Vec<Vec<ParseRepair>>);
 }
 
 pub enum RecoveryKind {

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -331,7 +331,7 @@ pub fn parse_rcvry
 
 /// After a parse error is encountered, the parser attempts to find a way of recovering. Each entry
 /// in the sequence of repairs is represented by a `ParseRepair`.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum ParseRepair {
     /// Insert a `Symbol::Term` with idx `term_idx`.
     InsertTerm{term_idx: TIdx},

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,6 @@ fn main() {
                 Some(pt) => println!("{}", pt.pp(&grm, &input)),
                 None     => println!("Unable to repair input sufficiently to produce parse tree.\n")
             }
-            let sg = grm.sentence_generator(&ic);
             for e in errs {
                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
                 println!("Error detected at line {} col {}. Amongst the valid repairs are:", line, col);
@@ -185,14 +184,14 @@ fn main() {
                     let mut out = vec![];
                     for r in repair.iter() {
                         match *r {
-                            ParseRepair::InsertNonterm(nonterm_idx) => {
+                            ParseRepair::InsertSeq(ref seqs) => {
                                 let mut s = String::new();
                                 s.push_str("Insert {");
-                                for (i, snt) in sg.min_sentences(nonterm_idx).iter().enumerate() {
+                                for (i, seq) in seqs.iter().enumerate() {
                                     if i > 0 {
                                         s.push_str(", ");
                                     }
-                                    for (j, t_idx) in snt.iter().enumerate() {
+                                    for (j, t_idx) in seq.iter().enumerate() {
                                         if j > 0 {
                                             s.push_str(" ");
                                         }
@@ -202,7 +201,7 @@ fn main() {
                                 s.push_str("}");
                                 out.push(s);
                             },
-                            ParseRepair::InsertTerm(term_idx) =>
+                            ParseRepair::Insert(term_idx) =>
                                 out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
                             ParseRepair::Delete | ParseRepair::Shift => {
                                 let l = lexemes[lex_idx];

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() {
                     let mut out = vec![];
                     for r in repair.iter() {
                         match *r {
-                            ParseRepair::InsertNonterm{nonterm_idx} => {
+                            ParseRepair::InsertNonterm(nonterm_idx) => {
                                 let mut s = String::new();
                                 s.push_str("Insert {");
                                 for (i, snt) in sg.min_sentences(nonterm_idx).iter().enumerate() {
@@ -202,7 +202,7 @@ fn main() {
                                 s.push_str("}");
                                 out.push(s);
                             },
-                            ParseRepair::InsertTerm{term_idx} =>
+                            ParseRepair::InsertTerm(term_idx) =>
                                 out.push(format!("Insert \"{}\"", grm.term_name(term_idx).unwrap())),
                             ParseRepair::Delete | ParseRepair::Shift => {
                                 let l = lexemes[lex_idx];

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,8 +183,8 @@ fn main() {
                 for repair in e.repairs() {
                     let mut lex_idx = e.lexeme_idx();
                     let mut out = vec![];
-                    for &r in repair {
-                        match r {
+                    for r in repair.iter() {
+                        match *r {
                             ParseRepair::InsertNonterm{nonterm_idx} => {
                                 let mut s = String::new();
                                 s.push_str("Insert {");
@@ -207,7 +207,7 @@ fn main() {
                             ParseRepair::Delete | ParseRepair::Shift => {
                                 let l = lexemes[lex_idx];
                                 let t = &input[l.start()..l.start() + l.len()].replace("\n", "\\n");
-                                if let ParseRepair::Delete = r {
+                                if let ParseRepair::Delete = *r {
                                     out.push(format!("Delete \"{}\"", t));
                                 } else {
                                     out.push(format!("Keep \"{}\"", t));


### PR DESCRIPTION
This is, in some senses, an incomplete pull request, but it's still probably complete enough to be worth merging. The original plan was to make it possible to make KimYiPlus repairs easier to understand, merging things like:

```
  Insert X, Insert Y
  Insert X, Insert Z
```

into:

```
  Insert X, Insert {Y, Z}
```

Doing this requires moving away from the idea that inserting a nonterm tells us anything useful: there may be no relation between Y and Z from the grammars point of view, but users don't think in terms of grammar, so it's better to flatten things.

While working on this PR, I found (finally) examples where KimYi and KimYiPlus don't work properly. I've been working on that in a separate branch forked from this one. I still have more work to do on that, but it's pretty clear that it's moving in a useful direction. That means that I'm not going to be able to finish this PR completely until the "newer" PR is completed. So I think it's worth looking at this PR now and, if we're happy, merging it.

This PR thus doesn't do any merging of repairs, but it does all the preparatory work needed for merging to be possible. The first 4 commits are largely or wholly mechanical. The final commit (https://github.com/softdevteam/lrpar/commit/e182c21d0de8b3df3350d587e6952dc90d620089) is really the important commit. `Repair::InsertNonterm` (which inserts a given nonterminal) becomes `Repair::InserSeq` (which stores 1 or more nonterminals, any of which can be inserted at this point in the grammar).