### PR TITLE
MF: a new recovery algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,6 @@ cactus = "1.0.0"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
+num-traits = "0.1.41"
+ordermap = "0.3.5"
 pathfinding = "0.2.4"

--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -1,0 +1,146 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::iter::FromIterator;
+
+use num_traits::{CheckedAdd, Zero};
+use ordermap::OrderSet;
+
+/// Starting at `start_node`, return, in arbitrary order, all least-cost success nodes.
+///
+/// * `neighbours` takes a node `n` and returns an iterator consisting of all `n`'s neighbouring
+/// nodes.
+/// * `success` takes a node `n` and returns `true` if it is a success node or `false` otherwise.
+///
+/// This API is roughly modelled after
+/// [`astar_bag_collect`](https://docs.rs/pathfinding/0.6.8/pathfinding/fn.astar_bag.html)
+/// in the `pathfinding` crate. Unlike `astar_bag_collect`, this `astar_all` does not record the
+/// path taken to reach a success node: this allows it to be substantially faster.
+pub(crate) fn astar_all<N, C, FN, IN, FS>(start_node: N,
+                                          neighbours: FN,
+                                          success: FS)
+                                       -> Vec<N>
+                                    where N: Debug + Eq + Hash + Clone,
+                                          C: CheckedAdd + Copy + Debug + Hash + Ord + Zero,
+                                          usize: TryFrom<C>,
+                                          FN: Fn(&N) -> IN,
+                                          IN: IntoIterator<Item = (C, C, N)>,
+                                          FS: Fn(&N) -> bool,
+{
+    // We tackle the problem in two phases. In the first phase we search for a success node, with
+    // the cost monotonically increasing. All neighbouring nodes are stored for future inspection,
+    // even if they're of higher cost than the current node. The second phase begins as soon as
+    // we've found the first success node. At this point, we still need to search for neighbours,
+    // but we can discard any nodes of greater cost than the first success node.
+    //
+    // The advantage of this two-phase split is that in the second phase we need do substantially
+    // less computation and storage of nodes.
+
+    // First phase: search for the first success node.
+
+    let mut scs_nodes = OrderSet::new(); // Store success nodes
+    let scs_cost: C;  // What is the cost of a success node?
+    let mut todo: Vec<(usize, OrderSet<(C, C, N)>)> = Vec::new();
+    todo.push((0, orderset![(Zero::zero(), Zero::zero(), start_node)]));
+    let mut next_todo = Vec::new(); // An intermediate list to help todo
+    let mut i = 0; // How far through the todo list are we?
+    loop {
+        next_todo.clear();
+        {
+            let j = todo[i].0;
+            if j == todo[i].1.len() {
+                // We'll never need the lower cost node information again, so clear the associated
+                // memory.
+                todo[i].1.clear();
+
+                i += 1;
+                if i == todo.len() {
+                    // No success node found and search exhausted.
+                    return Vec::new();
+                }
+                continue;
+            }
+
+            let &(c, h, ref n) = todo[i].1.get_index(j).unwrap();
+            if success(&n) {
+                assert!(h == Zero::zero());
+                scs_cost = c;
+                break;
+            }
+
+            for (nbr_cost, nbr_hrstc, nbr) in neighbours(n) {
+                assert!(nbr_cost >= c && nbr_cost + nbr_hrstc >= c + h);
+                let off = usize::try_from(nbr_cost.checked_add(&nbr_hrstc).unwrap()).ok().unwrap();
+                next_todo.push((off, ((nbr_cost, nbr_hrstc, nbr.clone()))));
+            }
+        }
+
+        for (off, tup) in next_todo.drain(..) {
+            for _ in todo.len()..off + 1 {
+                todo.push((0, OrderSet::new()));
+            }
+            todo[off].1.insert(tup);
+        }
+        todo[i].0 += 1;
+    }
+
+    // Second phase: find remaining success nodes.
+
+    // Free up all memory except for the cost todo that contains the first success node.
+    let (mut j, mut scs_todo) = todo.drain(i..i + 1).nth(0).unwrap();
+    let mut next_todo = Vec::new();
+    while j < scs_todo.len() {
+        next_todo.clear();
+        {
+            let &(_, h, ref n) = scs_todo.get_index(j).unwrap();
+            if success(&n) {
+                assert!(h == Zero::zero());
+                scs_nodes.insert(n.clone());
+            }
+            for (nbr_cost, nbr_hrstc, nbr) in neighbours(n) {
+                assert!(nbr_cost + nbr_hrstc >= scs_cost);
+                // We only need to consider neighbouring nodes if they have the same cost as
+                // existing success nodes and an empty heuristic.
+                if nbr_cost + nbr_hrstc == scs_cost {
+                    next_todo.push((nbr_cost, nbr_hrstc, nbr));
+                }
+            }
+        }
+        scs_todo.extend(next_todo.drain(..));
+        j += 1;
+    }
+
+    Vec::from_iter(scs_nodes)
+}

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -31,7 +31,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::cmp::Ordering;
-use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 
@@ -102,7 +101,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                     return vec![];
                 }
 
-                let mut nbrs = HashSet::new();
+                let mut nbrs = Vec::new();
                 match n.repairs.val() {
                     Some(&Repair::Delete) => {
                         // We follow Corcheulo et al.'s suggestions and never follow Deletes with

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -1,0 +1,536 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::cmp::Ordering;
+use std::collections::HashSet;
+use std::convert::{TryFrom, TryInto};
+use std::fmt::Debug;
+
+use cactus::Cactus;
+use cfgrammar::Symbol;
+use cfgrammar::yacc::SentenceGenerator;
+use lrtable::{Action, StIdx};
+use pathfinding::astar_bag;
+
+use kimyi::{apply_repairs, Dist, PathFNode, Repair, r3is, r3ir, r3d, r3s_n};
+use parser::{Node, Parser, ParseRepair, Recoverer};
+
+const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
+const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
+const TRY_PARSE_AT_MOST: usize = 250;
+
+pub(crate) struct MF<'a> {
+    dist: Dist,
+    sg: SentenceGenerator<'a>
+}
+
+pub(crate) fn recoverer<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                       (parser: &'a Parser<TokId>)
+                     -> Box<Recoverer<TokId> + 'a>
+{
+    let dist = Dist::new(parser.grm, parser.sgraph, |x| parser.ic(Symbol::Term(x)));
+    let sg = parser.grm.sentence_generator(|x| parser.ic(Symbol::Term(x)));
+    Box::new(MF{dist, sg})
+}
+
+impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+    Recoverer<TokId> for MF<'a>
+{
+    fn recover(&self,
+               parser: &Parser<TokId>,
+               in_la_idx: usize,
+               in_pstack: &mut Vec<StIdx>,
+               mut tstack: &mut Vec<Node<TokId>>)
+           -> (usize, Vec<Vec<ParseRepair>>)
+    {
+        // This function implements an algorithm whose core is based on that from "LR error repair
+        // using the A* algorithm" by Ik-Soon Kim and Kwangkeun Yi. However, we extend it in
+        // several ways.
+        //
+        // The basic idea behind this implementation is to use the transition rules from Fig 9
+        // (along with the altered version of R3S presented on p12) as a mechanism for dynamically
+        // calculating the neighbours of the current node under investigation. Unlike KimYi, who
+        // non-deterministically return a single repair, this variant evaluates all minimal cost
+        // repairs.
+
+        let mut start_cactus_pstack = Cactus::new();
+        for st in in_pstack.drain(..) {
+            start_cactus_pstack = start_cactus_pstack.child(st);
+        }
+
+        let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
+                                   la_idx: in_la_idx,
+                                   t: 1,
+                                   repairs: Cactus::new(),
+                                   cf: 0,
+                                   cg: 0};
+        let (astar_cnds, _) = astar_bag(
+            &start_node,
+            |n| {
+                // Calculate n's neighbours.
+
+                if n.la_idx > in_la_idx + PORTION_THRESHOLD {
+                    return vec![];
+                }
+
+                let mut nbrs = HashSet::new();
+                match n.repairs.val() {
+                    Some(&Repair::Delete) => {
+                        // We follow Corcheulo et al.'s suggestions and never follow Deletes with
+                        // Inserts.
+                    },
+                    _ => {
+                        r3is(parser, &self.dist, &n, &mut nbrs);
+                        r3ir(parser, &self.sg, &n, &mut nbrs);
+                    }
+                }
+                r3d(parser, &n, &mut nbrs);
+                r3s_n(parser, &n, &mut nbrs);
+                let v = nbrs.into_iter()
+                            .map(|x| {
+                                    let t = x.cf - n.cf;
+                                    (x, t)
+                                 })
+                            .collect::<Vec<(PathFNode, _)>>();
+                v
+            },
+            |n| n.cg,
+            |n| {
+                // Is n a success node?
+
+                // As presented in both Corchuelo et al. and Kim Yi, one type of success is if N
+                // symbols are parsed in one go. Indeed, without such a check, the search space
+                // quickly becomes too big. There isn't a way of encoding this check in r3s_n, so
+                // we check instead for its result: if the last N ('PARSE_AT_LEAST' in this
+                // library) repairs are shifts, then we've found a success node.
+                if n.repairs.len() > PARSE_AT_LEAST {
+                    let mut all_shfts = true;
+                    for x in n.repairs.vals().take(PARSE_AT_LEAST) {
+                        if let Repair::Shift = *x {
+                            continue;
+                        }
+                        all_shfts = false;
+                        break;
+                    }
+                    if all_shfts {
+                        return true;
+                    }
+                }
+
+                let (_, la_term) = parser.next_lexeme(None, n.la_idx);
+                match parser.stable.action(*n.pstack.val().unwrap(), la_term) {
+                    Some(Action::Accept) => true,
+                    _ => false,
+                }
+            });
+
+        if astar_cnds.is_empty() {
+            return (in_la_idx, vec![]);
+        }
+
+        let full_rprs = collect_repairs(astar_cnds);
+        let smpl_rprs = simplify_repairs(parser, full_rprs);
+        let rnk_rprs = rank_cnds(parser,
+                                 in_la_idx,
+                                 start_cactus_pstack.clone(),
+                                 smpl_rprs);
+        let (la_idx, mut rpr_pstack) = apply_repairs(parser,
+                                                     in_la_idx,
+                                                     start_cactus_pstack,
+                                                     &mut Some(&mut tstack),
+                                                     &rnk_rprs[0]);
+
+        in_pstack.clear();
+        while !rpr_pstack.is_empty() {
+            let p = rpr_pstack.parent().unwrap();
+            in_pstack.push(rpr_pstack.try_unwrap()
+                                     .unwrap_or_else(|c| c.val()
+                                                          .unwrap()
+                                                          .clone()));
+            rpr_pstack = p;
+        }
+        in_pstack.reverse();
+
+        (la_idx, rnk_rprs)
+    }
+}
+
+/// Convert the output from `astar_bag` into something more usable.
+fn collect_repairs(cnds: Vec<Vec<PathFNode>>) -> Vec<Vec<Repair>>
+{
+    let mut all_rprs = Vec::new();
+    for mut rprs in cnds.into_iter() {
+        let mut y = rprs.pop()
+                        .unwrap()
+                        .repairs
+                        .vals()
+                        .cloned()
+                        .collect::<Vec<Repair>>();
+        y.reverse();
+        all_rprs.push(y);
+    }
+    all_rprs
+}
+
+/// Take an (unordered) set of parse repairs and return a simplified (unordered) set of parse
+/// repairs. Note that the caller must make no assumptions about the size or contents of the output
+/// set: this function might delete, expand, or do other things to repairs.
+fn simplify_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+                   (parser: &Parser<TokId>,
+                    mut all_rprs: Vec<Vec<Repair>>)
+                 -> Vec<Vec<ParseRepair>>
+{
+    let sg = parser.grm.sentence_generator(|x| parser.ic(Symbol::Term(x)));
+    for i in 0..all_rprs.len() {
+        {
+            // Remove all inserts of nonterms which have a minimal sentence cost of 0.
+            let mut rprs = all_rprs.get_mut(i).unwrap();
+            let mut j = 0;
+            while j < rprs.len() {
+                if let Repair::InsertNonterm(nonterm_idx) = rprs[j] {
+                    if sg.min_sentence_cost(nonterm_idx) == 0 {
+                        rprs.remove(j);
+                    } else {
+                        j += 1;
+                    }
+                } else {
+                    j += 1;
+                }
+            }
+        }
+
+        {
+            // Remove shifts from the end of repairs
+            let mut rprs = all_rprs.get_mut(i).unwrap();
+            while rprs.len() > 0 {
+                if let Repair::Shift = rprs[rprs.len() - 1] {
+                    rprs.pop();
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    // The simplifications above can mean that we now end up with equivalent repairs. Remove
+    // duplicates.
+
+    let mut i = 0;
+    while i < all_rprs.len() {
+        let mut j = i + 1;
+        while j < all_rprs.len() {
+            if all_rprs[i] == all_rprs[j] {
+                all_rprs.remove(j);
+            } else {
+                j += 1;
+            }
+        }
+        i += 1;
+    }
+
+    all_rprs.iter()
+            .map(|x| x.iter()
+                      .map(|y| {
+                                    match *y {
+                                        Repair::InsertTerm(term_idx) =>
+                                            ParseRepair::Insert(term_idx),
+                                        Repair::InsertNonterm(nonterm_idx) =>
+                                            ParseRepair::InsertSeq(sg.min_sentences(nonterm_idx)),
+                                        Repair::Delete => ParseRepair::Delete,
+                                        Repair::Shift => ParseRepair::Shift,
+                                    }
+                           })
+                      .collect())
+                  .collect()
+}
+
+/// Convert `PathFNode` candidates in `cnds` into vectors of `ParseRepairs`s and rank them (from
+/// highest to lowest) by the distance they allow parsing to continue without error. If two or more
+/// `ParseRepair`s allow the same distance of parsing, then the `ParseRepair` which requires
+/// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
+/// ordering is non-deterministic.
+fn rank_cnds<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq>
+            (parser: &Parser<TokId>,
+             in_la_idx: usize,
+             start_pstack: Cactus<StIdx>,
+             in_cnds: Vec<Vec<ParseRepair>>)
+          -> Vec<Vec<ParseRepair>>
+{
+    let mut cnds = in_cnds.into_iter()
+                          .map(|rprs| {
+                               let (la_idx, pstack) = apply_repairs(parser,
+                                                                    in_la_idx,
+                                                                    start_pstack.clone(),
+                                                                    &mut None,
+                                                                    &rprs);
+                               (pstack, la_idx, rprs)
+                           })
+                          .collect::<Vec<(Cactus<StIdx>, usize, Vec<ParseRepair>)>>();
+
+    // First try parsing each candidate repair until it hits an error or exceeds TRY_PARSE_AT_MOST
+    // lexemes.
+
+    let mut todo = Vec::new();
+    todo.resize(cnds.len(), true);
+    let mut remng = cnds.len(); // Remaining items in todo
+    let mut i = 0;
+    while i < TRY_PARSE_AT_MOST && remng > 1 {
+        let mut j = 0;
+        while j < todo.len() {
+            if !todo[j] {
+                j += 1;
+                continue;
+            }
+            let cnd = cnds.get_mut(j).unwrap();
+            if cnd.1 > in_la_idx + i {
+                j += 1;
+                continue;
+            }
+            let (new_la_idx, new_pstack) = parser.lr_cactus(None,
+                                                            in_la_idx + i,
+                                                            in_la_idx + i + 1,
+                                                            cnd.0.clone(),
+                                                            &mut None);
+            if new_la_idx == in_la_idx + i {
+                todo[j] = false;
+                remng -= 1;
+            } else {
+                cnd.0 = new_pstack;
+                cnd.1 += 1;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+
+    // Now rank the candidates into descending order, first by how far they are able to parse, then
+    // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
+    // intuition that "repairs which affect the shortest part of the string are preferable").
+    cnds.sort_unstable_by(|x, y| {
+        match y.1.cmp(&x.1) {
+            Ordering::Equal => {
+                x.2.len().cmp(&y.2.len())
+            },
+            a => a
+        }
+    });
+
+    cnds.into_iter()
+        .map(|x| x.2)
+        .collect::<Vec<Vec<ParseRepair>>>()
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use cfgrammar::yacc::YaccGrammar;
+    use lrlex::Lexeme;
+
+    use parser::{ParseRepair, RecoveryKind};
+    use parser::test::do_parse;
+    use kimyi::test::{check_repairs, pp_repairs};
+
+    pub(crate) fn check_all_repairs(grm: &YaccGrammar,
+                                    repairs: &Vec<Vec<ParseRepair>>,
+                                    expected: &[&str]) {
+        assert_eq!(repairs.len(), expected.len(),
+                   "{:?}\nhas a different number of entries to:\n{:?}", repairs, expected);
+        for i in 0..repairs.len() {
+            if expected.iter().find(|x| **x == pp_repairs(&grm, &repairs[i])).is_none() {
+                panic!("No match found for:\n  {}", pp_repairs(&grm, &repairs[i]));
+            }
+        }
+    }
+
+    #[test]
+    fn corchuelo_example() {
+        // The example from the Corchuelo paper
+        let lexs = "%%
+[(] OPEN_BRACKET
+[)] CLOSE_BRACKET
+[+] PLUS
+n N
+";
+        let grms = "%start E
+%%
+E : 'N'
+  | E 'PLUS' 'N'
+  | 'OPEN_BRACKET' E 'CLOSE_BRACKET'
+  ;
+";
+
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "(nn");
+        let (pt, errs) = pr.unwrap_err();
+        let pp = pt.unwrap().pp(&grm, "(nn");
+        if !vec![
+"E
+ OPEN_BRACKET (
+ E
+  N n
+ CLOSE_BRACKET 
+",
+"E
+ E
+  OPEN_BRACKET (
+  E
+   N n
+  CLOSE_BRACKET 
+ PLUS 
+ N n
+"]
+            .iter()
+            .any(|x| *x == pp) {
+            panic!("Can't find a match for {}", pp);
+        }
+
+        assert_eq!(errs.len(), 1);
+        let err_tok_id = u16::try_from(usize::from(grm.term_idx("N").unwrap())).ok().unwrap();
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
+        assert_eq!(errs[0].repairs().len(), 3);
+        check_repairs(&grm,
+                      errs[0].repairs(),
+                      &vec!["Insert \"CLOSE_BRACKET\", Insert \"PLUS\"",
+                            "Insert \"CLOSE_BRACKET\", Delete",
+                            "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\""]);
+
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "n)+n+n+n)");
+        let (_, errs) = pr.unwrap_err();
+        assert_eq!(errs.len(), 2);
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Delete"]);
+        check_all_repairs(&grm,
+                          errs[1].repairs(),
+                          &vec!["Delete"]);
+
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "(((+n)+n+n+n)");
+        let (_, errs) = pr.unwrap_err();
+        assert_eq!(errs.len(), 2);
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Insert \"N\"",
+                                "Delete"]);
+        check_all_repairs(&grm,
+                          errs[1].repairs(),
+                          &vec!["Insert \"CLOSE_BRACKET\""]);
+    }
+
+
+    #[test]
+    fn kimyi_example() {
+        // The example from the KimYi paper, with a bit of alpha-renaming to make it clearer. The
+        // paper uses "A" as a nonterminal name and "a" as a terminal name, which are then easily
+        // confused. Here we use "E" as the nonterminal name, and keep "a" as the terminal name.
+        let lexs = "%%
+[(] OPEN_BRACKET
+[)] CLOSE_BRACKET
+a A
+b B
+";
+        let grms = "%start E
+%%
+E: 'OPEN_BRACKET' E 'CLOSE_BRACKET'
+ | 'A'
+ | 'B' ;
+";
+
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "((");
+        let (pt, errs) = pr.unwrap_err();
+        let pp = pt.unwrap().pp(&grm, "((");
+        if !vec![
+"E
+ OPEN_BRACKET (
+ E
+  OPEN_BRACKET (
+  E
+   A 
+  CLOSE_BRACKET 
+ CLOSE_BRACKET 
+",
+"E
+ OPEN_BRACKET (
+ E
+  OPEN_BRACKET (
+  E
+   B 
+  CLOSE_BRACKET 
+ CLOSE_BRACKET 
+"]
+            .iter()
+            .any(|x| *x == pp) {
+            panic!("Can't find a match for {}", pp);
+        }
+        assert_eq!(errs.len(), 1);
+        let err_tok_id = u16::try_from(usize::from(grm.eof_term_idx())).ok().unwrap();
+        assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 0));
+        assert_eq!(errs[0].repairs().len(), 1);
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Insert {\"A\", \"B\"}, Insert \"CLOSE_BRACKET\", Insert \"CLOSE_BRACKET\""]);
+    }
+
+    #[test]
+    fn expr_grammar() {
+        let lexs = "%%
+[(] OPEN_BRACKET
+[)] CLOSE_BRACKET
+[+] PLUS
+[*] MULT
+[0-9]+ INT
+[ ] ;
+";
+
+        let grms = "%start Expr
+%%
+Expr: Term 'PLUS' Expr
+    | Term ;
+
+Term: Factor 'MULT' Term
+    | Factor ;
+
+Factor: 'OPEN_BRACKET' Expr 'CLOSE_BRACKET'
+      | 'INT' ;
+";
+
+        let us = "(2 3";
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);
+        let (_, errs) = pr.unwrap_err();
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Insert \"CLOSE_BRACKET\", Insert \"PLUS\"",
+                                "Insert \"CLOSE_BRACKET\", Insert \"MULT\"",
+                                "Insert \"CLOSE_BRACKET\", Delete",
+                                "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\"",
+                                "Insert \"MULT\", Shift, Insert \"CLOSE_BRACKET\""]);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -43,3 +43,4 @@ pub mod parser;
 pub use parser::{ParseRepair, RecoveryKind};
 mod kimyi;
 mod kimyi_plus;
+mod mf;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -30,6 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#![feature(step_trait)]
 #![feature(test)]
 #![feature(try_from)]
 
@@ -37,9 +38,12 @@ extern crate cactus;
 extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrtable;
+extern crate num_traits;
+#[macro_use] extern crate ordermap;
 extern crate pathfinding;
 extern crate test;
 
+mod astar;
 mod corchuelo;
 pub mod parser;
 pub use parser::{ParseRepair, RecoveryKind};

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -30,6 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#![feature(test)]
 #![feature(try_from)]
 
 extern crate cactus;
@@ -37,6 +38,7 @@ extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrtable;
 extern crate pathfinding;
+extern crate test;
 
 mod corchuelo;
 pub mod parser;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -40,6 +40,7 @@ use lrtable::{Action, StateGraph, StateTable, StIdx};
 
 use kimyi;
 use kimyi_plus;
+use mf;
 use corchuelo;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -168,6 +169,8 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                                                  kimyi::recoverer(&self),
                                              RecoveryKind::KimYiPlus =>
                                                  kimyi_plus::recoverer(&self),
+                                             RecoveryKind::MF =>
+                                                 mf::recoverer(&self),
                                          });
                     }
 
@@ -297,7 +300,8 @@ pub trait Recoverer<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize
 pub enum RecoveryKind {
     Corchuelo,
     KimYi,
-    KimYiPlus
+    KimYiPlus,
+    MF
 }
 
 /// Parse the lexemes. On success return a parse tree. On failure, return a parse tree (if all the

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -109,10 +109,9 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
         let mut tstack: Vec<Node<TokId>> = Vec::new();
         let mut errors: Vec<ParseError<TokId>> = Vec::new();
         let accpt = psr.lr(0, &mut pstack, &mut tstack, &mut errors);
-        let t = tstack.drain(..).nth(0).unwrap();
         match (accpt, errors.is_empty()) {
-            (true, true)   => Ok(t),
-            (true, false)  => Err((Some(t), errors)),
+            (true, true)   => Ok(tstack.drain(..).nth(0).unwrap()),
+            (true, false)  => Err((Some(tstack.drain(..).nth(0).unwrap()), errors)),
             (false, false) => Err((None, errors)),
             (false, true)  => panic!("Internal error")
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
     let lexemes = lexer.lexemes().unwrap();
     let ic = |_| 1; // Cost of inserting a terminal
     let dc = |_| 1; // Cost of deleting a terminal
-    match parse_rcvry::<u16, _, _>(RecoveryKind::KimYiPlus, &grm, &ic, dc, &sgraph, &stable, &lexemes) {
+    match parse_rcvry::<u16, _, _>(RecoveryKind::MF, &grm, &ic, dc, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((o_pt, errs)) => {
             match o_pt {


### PR DESCRIPTION
This PR looks scary, but it's not quite as bad as it first looks if you take the commits one-by-one. The first few commits are boiler-plate stuff. https://github.com/softdevteam/lrpar/commit/ba35e6aed3ae8fc8be8d9d94901a03aff600ae26 is the main commit, giving us a completely new recovery algorithm. https://github.com/softdevteam/lrpar/pull/40/commits/03de1fa669e0dba4841c55b8101f23ad612ea807 is a relatively stand-alone performance change. The other latter commits are relatively simple changes. The important commits are extensively documented (hopefully) in both the commit messages and (where useful) in the code.

The problem this PR tries to solve is that the KimYi recoverer (either in KimYi or KimYiPlus modes) is flawed. Here's a simple grammar:

```
S: T U 'C';
T: 'A';
U: 'B';
```

Given the input "c", KimYi can't find any repairs, even though it looks like it should.

This PR introduces a new recoverer "MF" (the name is mostly meaningless), which is heavily inspired by KimYi. For the above example, it finds the repair:

```
Insert 'A', Insert 'B'
```

Sometimes KimYi's flaw means that it finds a longer repair than it should. Consider this grammar:

```
S:  'A' 'B' 'D' | 'A' 'B' 'C' 'A' 'A' 'D';
```

Give the input "acd", KimYi finds the following repair:

```
  Insert "B", Shift, Insert "A", Insert "A"
```

Whereas MF finds the following shorter repair:

```
  Insert "B", Delete
```

To make reviewing easier, MF reuses as much of KimYiPlus's code as possible, which means you can generally flick between `mf.rs` and `kimyi_plus.rs` to see what the differences are.

To cut a long story short, MF's major change is to rethink the dist() function. From a state S, KimYi tells us how many symbols need to be inserted to reach a terminal T. It does this by following edges with terminals in the stategraph. This fails to take into accout reductions and gotos, which means that KimYi::dist() often overestimates the true distance to T or incorrectly claims that T is unreachable. This then causes the A* algorithm to generate incorrect results (A* works fine if dist() underestimates the distance, but doesn't work properly if dist() overestimates).

MF's dist() algorithm takes into account reductions and gotos. This means that MF's dist is more conservative / pessimistic, but it means that it never overestimates the distance. The current MF::dist is pretty slow (taking several times as long as KimYi::dist), although that could be optimised a fair bit in the future. The changes to dist() then have a few knock-on effects (mostly simplifications) to the rules discovering repairs.

The good news is that, overall, performance is almost identical between MF and KimYiPlus (mostly because the new A* algorithm in this PR wins back what we lose from having a more conservative dist() function). There is definitely a need for more optimisation, but at least we now have an approach which is less obviously flawed.