### PR TITLE
Fix the new_lexeme API

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -128,7 +128,7 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
                                 // We make the artificially inserted lexeme appear to start at the
                                 // same position as the real next lexeme, but have zero length (so
                                 // that it's clear it's not really something the user created).
-                                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                                let next_lexeme = parser.next_lexeme(la_idx);
                                 let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
                                                                             .ok()
                                                                             .unwrap(),
@@ -253,7 +253,7 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
             for r in repairs[0].iter() {
                 match *r {
                     Repair::InsertTerm{term_idx} => {
-                        let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                        let next_lexeme = parser.next_lexeme(la_idx);
                         let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
                                                                     .ok()
                                                                     .unwrap(),

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -201,7 +201,7 @@ impl<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> 
                     } else {
                         debug_assert!(new_la_idx < la_idx + PARSE_AT_LEAST);
                         let st = *n_pstack.val().unwrap();
-                        let la_tidx = parser.next_lexeme(None, new_la_idx).1;
+                        let la_tidx = parser.next_tidx(new_la_idx);
                         match parser.stable.action(st, Symbol::Term(la_tidx)) {
                             Some(Action::Accept) => finisher = true,
                             None => (),

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -200,7 +200,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                     }
                 }
 
-                let la_tidx = parser.next_lexeme(None, n.la_idx).1;
+                let la_tidx = parser.next_tidx(n.la_idx);
                 match parser.stable.action(*n.pstack.val().unwrap(), Symbol::Term(la_tidx)) {
                     Some(Action::Accept) => true,
                     _ => false,
@@ -244,7 +244,7 @@ pub(crate) fn r3is<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize>
                    nbrs: &mut Vec<PathFNode>)
 {
     let top_pstack = *n.pstack.val().unwrap();
-    let la_tidx = parser.next_lexeme(None, n.la_idx).1;
+    let la_tidx = parser.next_tidx(n.la_idx);
     for (&sym, &sym_st_idx) in parser.sgraph.edges(top_pstack).iter() {
         if let Symbol::Term(term_idx) = sym {
             if term_idx == parser.grm.eof_term_idx() {
@@ -334,7 +334,7 @@ pub(crate) fn r3d<TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> 
         return;
     }
 
-    let la_tidx = parser.next_lexeme(None, n.la_idx).1;
+    let la_tidx = parser.next_tidx(n.la_idx);
     let nn = PathFNode{pstack: n.pstack.clone(),
                        la_idx: n.la_idx + 1,
                        t: 1,

--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -442,7 +442,7 @@ pub(crate) fn apply_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryIn
     for r in repairs.iter() {
         match *r {
             ParseRepair::InsertSeq(ref seqs) => {
-                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                let next_lexeme = parser.next_lexeme(la_idx);
                 for &t_idx in seqs[0].iter() {
                     let new_lexeme = Lexeme::new(TokId::try_from(usize::from(t_idx))
                                                                 .ok()
@@ -453,7 +453,7 @@ pub(crate) fn apply_repairs<TokId: Clone + Copy + Debug + TryFrom<usize> + TryIn
                 }
             },
             ParseRepair::Insert(term_idx) => {
-                let (next_lexeme, _) = parser.next_lexeme(None, la_idx);
+                let next_lexeme = parser.next_lexeme(la_idx);
                 let new_lexeme = Lexeme::new(TokId::try_from(usize::from(term_idx))
                                                             .ok()
                                                             .unwrap(),

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -145,7 +145,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                     }
                 }
 
-                let la_tidx = parser.next_lexeme(None, n.la_idx).1;
+                let la_tidx = parser.next_tidx(n.la_idx);
                 match parser.stable.action(*n.pstack.val().unwrap(), Symbol::Term(la_tidx)) {
                     Some(Action::Accept) => true,
                     _ => false,

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -159,7 +159,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                     }
                 }
 
-                let la_tidx = parser.next_lexeme(None, n.la_idx).1;
+                let la_tidx = parser.next_tidx(n.la_idx);
                 match parser.stable.action(*n.pstack.val().unwrap(), Symbol::Term(la_tidx)) {
                     Some(Action::Accept) => true,
                     _ => false,
@@ -269,7 +269,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 
         let n_repairs = n.repairs.child(Repair::Delete);
         if let Some(d) = self.dyn_dist(&n_repairs, *n.pstack.val().unwrap(), n.la_idx + 1) {
-            let la_tidx = self.parser.next_lexeme(None, n.la_idx).1;
+            let la_tidx = self.parser.next_tidx(n.la_idx);
             let cost = (self.parser.term_cost)(la_tidx);
             let nn = PathFNode{pstack: n.pstack.clone(),
                                la_idx: n.la_idx + 1,
@@ -510,7 +510,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
         // "=" to "y" is 0. Assuming the deletion cost of "}" is 1, it's therefore cheaper to
         // delete "}" and add that to the distance from "=" to "y". Thus the cheapest distance is
         // 1.
-        let frst_tidx = self.parser.next_lexeme(None, la_idx).1;
+        let frst_tidx = self.parser.next_tidx(la_idx);
         let mut ld = self.dist.dist(st_idx, frst_tidx)
                               .unwrap_or(u32::max_value()); // ld == Current least distance
         let mut dc = (self.parser.term_cost)(frst_tidx) as u32; // Cumulative deletion cost
@@ -521,7 +521,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                 // a lower cost.
                 break;
             }
-            let t_idx = self.parser.next_lexeme(None, i).1;
+            let t_idx = self.parser.next_tidx(i);
             if let Some(d) = self.dist.dist(st_idx, t_idx) {
                 if dc.checked_add(d).unwrap() < ld {
                     ld = dc + d;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -149,7 +149,7 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                     pstack.push(self.stable.goto(prior, NTIdx::from(nonterm_idx)).unwrap());
                 },
                 Some(Action::Shift(state_id)) => {
-                    let (la_lexeme, _) = self.next_lexeme(None, la_idx);
+                    let la_lexeme = self.next_lexeme(la_idx);
                     tstack.push(Node::Term{lexeme: la_lexeme});
                     pstack.push(state_id);
                     la_idx += 1;
@@ -177,7 +177,7 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                                                          .as_ref()
                                                          .recover(&self, la_idx, pstack, tstack);
                     let keep_going = repairs.len() != 0;
-                    let (la_lexeme, _) = self.next_lexeme(None, la_idx);
+                    let la_lexeme = self.next_lexeme(la_idx);
                     errors.push(ParseError{state_idx: st, lexeme_idx: la_idx,
                                            lexeme: la_lexeme, repairs: repairs});
                     if !keep_going {
@@ -189,33 +189,28 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
         }
     }
 
-    /// Return a (`Lexeme`, `TIdx`) pair of the next lemexe. When `lexeme_prefix` is not
-    /// `None`, that is the next lexeme. Otherwise it will be the next lexeme in `self.lexemes` or
-    /// a specially constructed lexeme representing EOF.
-    pub(crate) fn next_lexeme(&self, lexemes_prefix: Option<Lexeme<TokId>>, la_idx: usize)
-                          -> (Lexeme<TokId>, TIdx)
+    /// Return a `Lexeme` for the next lemexe (if `la_idx` == `self.lexemes.len()` this will be
+    /// a lexeme constructed to look as if contains the EOF terminal).
+    pub(crate) fn next_lexeme(&self, la_idx: usize) -> Lexeme<TokId>
     {
-        if let Some(l) = lexemes_prefix {
-            (l, TIdx::from(l.tok_id().try_into().ok().unwrap()))
-        } else if let Some(l) = self.lexemes.get(la_idx) {
-            (*l, TIdx::from(l.tok_id().try_into().ok().unwrap()))
+        let llen = self.lexemes.len();
+        debug_assert!(la_idx <= llen);
+        if la_idx < llen {
+            self.lexemes[la_idx]
         } else {
             // We have to artificially construct a Lexeme for the EOF lexeme.
-            debug_assert_eq!(la_idx, self.lexemes.len());
             let last_la_end;
-            if self.lexemes.len() == 0 {
+            if llen == 0 {
                 last_la_end = 0;
             } else {
                 debug_assert!(la_idx > 0);
                 let last_la = self.lexemes[la_idx - 1];
                 last_la_end = last_la.start() + last_la.len();
             }
-            let la_lexeme = Lexeme::new(TokId::try_from(usize::from(self.grm.eof_term_idx()))
-                                              .ok()
-                                              .unwrap(),
-                                        last_la_end, 0);
-
-            (la_lexeme, TIdx::from(self.grm.eof_term_idx()))
+            Lexeme::new(TokId::try_from(usize::from(self.grm.eof_term_idx()))
+                              .ok()
+                              .unwrap(),
+                        last_la_end, 0)
         }
     }
 
@@ -249,7 +244,11 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
         assert!(lexeme_prefix.is_none() || end_la_idx == la_idx + 1);
         while la_idx != end_la_idx {
             let st = *pstack.val().unwrap();
-            let (la_lexeme, la_tidx) = self.next_lexeme(lexeme_prefix, la_idx);
+            let la_tidx = if let Some(l) = lexeme_prefix {
+                              TIdx::from(l.tok_id().try_into().ok().unwrap())
+                          } else {
+                              self.next_tidx(la_idx)
+                          };
 
             match self.stable.action(st, Symbol::Term(la_tidx)) {
                 Some(Action::Reduce(prod_id)) => {
@@ -269,6 +268,11 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
                 },
                 Some(Action::Shift(state_id)) => {
                     if let &mut Some(ref mut tstack_uw) = tstack {
+                        let la_lexeme = if let Some(l) = lexeme_prefix {
+                                            l
+                                        } else {
+                                            self.next_lexeme(la_idx)
+                                        };
                         tstack_uw.push(Node::Term{lexeme: la_lexeme});
                     }
                     pstack = pstack.child(state_id);


### PR DESCRIPTION
This is a simple, almost entirely mechanical, PR. The `next_lexeme` function turned into an accidental behemoth: it does two different things depending on the input, and returns two different things. Of its many call-sites, only one needs this full functionality.

These two commits thus split this function:

```rust
fn next_lexeme(&self, lexemes_prefix: Option<Lexeme<TokId>>, la_idx: usize) -> (Lexeme<TokId>, TIdx)
```

into two:

```rust
fn next_lexeme(&self, la_idx: usize) -> Lexeme<TokId> {... }
fn next_tidx(&self, la_idx: usize) -> TIdx { ... }
```

This makes a lot of the code a little bit easier to understand.