### PR TITLE
Shift directly rather than using LR cactus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
 num-traits = "0.1.41"
-ordermap = "0.3.5"
 pathfinding = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 getopts = "0.2.15"
-cactus = "1.0.0"
+cactus = "1.0.1"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 lrlex = { git = "http://github.com/softdevteam/lrlex" }

--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -126,6 +126,10 @@ pub(crate) fn astar_all<N, C, FN, IN, FS>(start_node: N,
             if success(&n) {
                 assert!(h == Zero::zero());
                 scs_nodes.push(n.clone());
+                // There's no point in searching the neighbours of success nodes: they can only
+                // contain extra (zero-cost, by definition) shifts, which are uninteresting.
+                j += 1;
+                continue;
             }
             for (nbr_cost, nbr_hrstc, nbr) in neighbours(n) {
                 assert!(nbr_cost + nbr_hrstc >= scs_cost);

--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -33,7 +33,6 @@
 use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::iter::FromIterator;
 
 use num_traits::{CheckedAdd, Zero};
 
@@ -71,78 +70,61 @@ pub(crate) fn astar_all<N, C, FN, IN, FS>(start_node: N,
 
     let mut scs_nodes = Vec::new(); // Store success nodes
     let scs_cost: C;  // What is the cost of a success node?
-    let mut todo: Vec<(usize, Vec<(C, C, N)>)> = vec![(0, vec![(Zero::zero(), Zero::zero(), start_node)])];
-    let mut next_todo = Vec::new(); // An intermediate list to help todo
+    let mut todo: Vec<Vec<(C, C, N)>> = vec![vec![(Zero::zero(), Zero::zero(), start_node)]];
     let mut i = 0; // How far through the todo list are we?
     loop {
-        next_todo.clear();
-        {
-            let j = todo[i].0;
-            if j == todo[i].1.len() {
-                // We'll never need the lower cost node information again, so clear the associated
-                // memory.
-                todo[i].1.clear();
-
-                i += 1;
-                if i == todo.len() {
-                    // No success node found and search exhausted.
-                    return Vec::new();
-                }
-                continue;
+        if todo[i].is_empty() {
+            // We'll never need the lower cost node information again, so clear the associated
+            // memory.
+            todo[i].clear();
+            i += 1;
+            if i == todo.len() {
+                // No success node found and search exhausted.
+                return Vec::new();
             }
-
-            let (c, h, ref n) = todo[i].1[j];
-            if success(&n) {
-                assert!(h == Zero::zero());
-                scs_cost = c;
-                break;
-            }
-
-            for (nbr_cost, nbr_hrstc, nbr) in neighbours(n) {
-                assert!(nbr_cost >= c && nbr_cost + nbr_hrstc >= c + h);
-                let off = usize::try_from(nbr_cost.checked_add(&nbr_hrstc).unwrap()).ok().unwrap();
-                next_todo.push((off, ((nbr_cost, nbr_hrstc, nbr.clone()))));
-            }
+            continue;
         }
 
-        for (off, tup) in next_todo.drain(..) {
+        let (c, h, n) = todo[i].pop().unwrap();
+        if success(&n) {
+            assert!(h == Zero::zero());
+            scs_nodes.push(n);
+            scs_cost = c;
+            break;
+        }
+
+        for (nbr_cost, nbr_hrstc, nbr) in neighbours(&n) {
+            assert!(nbr_cost >= c && nbr_cost + nbr_hrstc >= c + h);
+            let off = usize::try_from(nbr_cost.checked_add(&nbr_hrstc).unwrap()).ok().unwrap();
             for _ in todo.len()..off + 1 {
-                todo.push((0, Vec::new()));
+                todo.push(Vec::new());
             }
-            todo[off].1.push(tup);
+            todo[off].push((nbr_cost, nbr_hrstc, nbr));
         }
-        todo[i].0 += 1;
     }
 
     // Second phase: find remaining success nodes.
 
     // Free up all memory except for the cost todo that contains the first success node.
-    let (mut j, mut scs_todo) = todo.drain(i..i + 1).nth(0).unwrap();
-    let mut next_todo = Vec::new();
-    while j < scs_todo.len() {
-        next_todo.clear();
-        {
-            let (_, h, ref n) = scs_todo[j];
-            if success(&n) {
-                assert!(h == Zero::zero());
-                scs_nodes.push(n.clone());
-                // There's no point in searching the neighbours of success nodes: they can only
-                // contain extra (zero-cost, by definition) shifts, which are uninteresting.
-                j += 1;
-                continue;
-            }
-            for (nbr_cost, nbr_hrstc, nbr) in neighbours(n) {
-                assert!(nbr_cost + nbr_hrstc >= scs_cost);
-                // We only need to consider neighbouring nodes if they have the same cost as
-                // existing success nodes and an empty heuristic.
-                if nbr_cost + nbr_hrstc == scs_cost {
-                    next_todo.push((nbr_cost, nbr_hrstc, nbr));
-                }
+    let mut scs_todo = todo.drain(i..i + 1).nth(0).unwrap();
+    while !scs_todo.is_empty() {
+        let (_, h, n) = scs_todo.pop().unwrap();
+        if success(&n) {
+            assert!(h == Zero::zero());
+            scs_nodes.push(n);
+            // There's no point in searching the neighbours of success nodes: they can only
+            // contain extra (zero-cost, by definition) shifts, which are uninteresting.
+            continue;
+        }
+        for (nbr_cost, nbr_hrstc, nbr) in neighbours(&n) {
+            assert!(nbr_cost + nbr_hrstc >= scs_cost);
+            // We only need to consider neighbouring nodes if they have the same cost as
+            // existing success nodes and an empty heuristic.
+            if nbr_cost + nbr_hrstc == scs_cost {
+                scs_todo.push((nbr_cost, nbr_hrstc, nbr));
             }
         }
-        scs_todo.extend(next_todo.drain(..));
-        j += 1;
     }
 
-    Vec::from_iter(scs_nodes)
+    scs_nodes
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -39,7 +39,6 @@ extern crate cfgrammar;
 extern crate lrlex;
 extern crate lrtable;
 extern crate num_traits;
-#[macro_use] extern crate ordermap;
 extern crate pathfinding;
 extern crate test;
 


### PR DESCRIPTION
After a couple of refactoring commits, this PR makes a major -- though not hugely intensive in terms of lines of codes -- change to the MF recoverer in https://github.com/softdevteam/lrpar/commit/982ea65f0a9d9c12e0f971e6e38ca755dd4f8ad0. This change then allows us to optimise the A* function significantly (https://github.com/softdevteam/lrpar/commit/cb9221c59e184dade7cfaab44b9814ad0c22d5b1, https://github.com/softdevteam/lrpar/commit/b4d4de27819bcc8ad6577aede0ee3ba6f6d9dbc4, and https://github.com/softdevteam/lrpar/commit/c615841e41193042ab4c2949f2e74351e64f2e51), with a final minor change (https://github.com/softdevteam/lrpar/commit/c615841e41193042ab4c2949f2e74351e64f2e51). The individual commits are extensively documented (I hope).

One thing that this PR ignores are grammars with shift/reduce reduce/reduce errors. At the moment those break the implicit guarantee that we can't ever search duplicates. That requires a fair few changes and I'd like to wait to a future PR.

In terms of performance, this makes my biggest standard example just over 3x faster, so it's a big difference.