### PR TITLE
Fix "check for N shifts at the end of repairs"

### DIFF
--- a/src/lib/kimyi.rs
+++ b/src/lib/kimyi.rs
@@ -43,7 +43,7 @@ use pathfinding::astar;
 
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
-const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
+const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]

--- a/src/lib/kimyi_plus.rs
+++ b/src/lib/kimyi_plus.rs
@@ -43,7 +43,7 @@ use pathfinding::astar_bag;
 use kimyi::{apply_repairs, Dist, PathFNode, Repair, r3is, r3ir, r3d, r3s_n};
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
-const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
+const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
 

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -536,17 +536,15 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 
 /// Do `repairs` end with enough Shift repairs to be considered a success node?
 fn ends_with_parse_at_least_shifts(repairs: &Cactus<Repair>) -> bool {
-    if repairs.len() >= PARSE_AT_LEAST {
-        for x in repairs.vals().take(PARSE_AT_LEAST) {
-            if let Repair::Shift = *x {
-                continue;
-            }
-            return false;
+    let mut shfts = 0;
+    for x in repairs.vals().take(PARSE_AT_LEAST) {
+        if let Repair::Shift = *x {
+            shfts += 1;
+            continue;
         }
-        true
-    } else {
-       false
+        return false;
     }
+    shfts == PARSE_AT_LEAST
 }
 
 pub(crate) struct Dist {

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -536,7 +536,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 
 /// Do `repairs` end with enough Shift repairs to be considered a success node?
 fn ends_with_parse_at_least_shifts(repairs: &Cactus<Repair>) -> bool {
-    if repairs.len() > PARSE_AT_LEAST {
+    if repairs.len() >= PARSE_AT_LEAST {
         for x in repairs.vals().take(PARSE_AT_LEAST) {
             if let Repair::Shift = *x {
                 continue;
@@ -733,16 +733,18 @@ mod test {
     use std::convert::TryFrom;
     use test::{Bencher, black_box};
 
+    use cactus::Cactus;
     use cfgrammar::Symbol;
     use cfgrammar::yacc::{yacc_grm, YaccGrammar, YaccKind};
     use lrlex::Lexeme;
     use lrtable::{Minimiser, from_yacc, StIdx};
 
+    use kimyi::Repair;
+    use kimyi::test::pp_repairs;
     use parser::{ParseRepair, RecoveryKind};
     use parser::test::do_parse;
-    use kimyi::test::pp_repairs;
 
-    use super::Dist;
+    use super::{ends_with_parse_at_least_shifts, Dist, PARSE_AT_LEAST};
 
     #[test]
     fn dist_kimyi() {
@@ -1194,5 +1196,27 @@ S: 'A';
                           errs[0].repairs(),
                           &vec!["Insert \"A\", Insert \"CLOSE_BRACKET\"",
                                 "Insert \"B\", Insert \"CLOSE_BRACKET\""]);
+    }
+
+    #[test]
+    fn test_counting_shifts() {
+        let mut c = Cactus::new();
+        assert_eq!(ends_with_parse_at_least_shifts(&c), false);
+        for _ in 0..PARSE_AT_LEAST - 1 {
+            c = c.child(Repair::Shift);
+            assert_eq!(ends_with_parse_at_least_shifts(&c), false);
+        }
+        c = c.child(Repair::Shift);
+        assert_eq!(ends_with_parse_at_least_shifts(&c), true);
+
+        let mut c = Cactus::new();
+        assert_eq!(ends_with_parse_at_least_shifts(&c), false);
+        c = c.child(Repair::Delete);
+        for _ in 0..PARSE_AT_LEAST - 1 {
+            c = c.child(Repair::Shift);
+            assert_eq!(ends_with_parse_at_least_shifts(&c), false);
+        }
+        c = c.child(Repair::Shift);
+        assert_eq!(ends_with_parse_at_least_shifts(&c), true);
     }
 }

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -45,7 +45,7 @@ use astar::astar_all;
 use kimyi::{apply_repairs, Repair};
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
-const PARSE_AT_LEAST: usize = 4; // N in Corchuelo et al.
+const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
 const PORTION_THRESHOLD: usize = 10; // N_t in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
 


### PR DESCRIPTION
The MF recoverer had an unfortunate off-by-one error (`>` instead of `>=`), which the first commit fixes. The second commit makes the check involved faster. The final commit makes all recoverers use the same threshold for determining if there are enough shifts to constitute success. The commit messages have a little more detail, although none is too fussy, since this is a relatively simple PR.