### PR TITLE
Optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,12 @@ lrlex = { git = "http://github.com/softdevteam/lrlex" }
 num-traits = "0.1.41"
 pathfinding = "0.2.4"
 vob = "0.1.0"
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'unwind'

--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -48,7 +48,7 @@ pub(crate) fn astar_all<N, FN, FS>(start_node: N,
                                    success: FS)
                                 -> Vec<N>
                              where N: Debug + Eq + Hash + Clone,
-                                   FN: Fn(&N, &mut Vec<(u32, u32, N)>),
+                                   FN: Fn(bool, &N, &mut Vec<(u32, u32, N)>),
                                    FS: Fn(&N) -> bool,
 {
     // We tackle the problem in two phases. In the first phase we search for a success node, with
@@ -87,7 +87,7 @@ pub(crate) fn astar_all<N, FN, FS>(start_node: N,
             break;
         }
 
-        neighbours(&n, &mut next);
+        neighbours(true, &n, &mut next);
         for (nbr_cost, nbr_hrstc, nbr) in next.drain(..) {
             assert!(nbr_cost + nbr_hrstc >= c);
             let off = nbr_cost.checked_add(nbr_hrstc).unwrap() as usize;
@@ -110,7 +110,7 @@ pub(crate) fn astar_all<N, FN, FS>(start_node: N,
             // contain extra (zero-cost, by definition) shifts, which are uninteresting.
             continue;
         }
-        neighbours(&n, &mut next);
+        neighbours(false, &n, &mut next);
         for (nbr_cost, nbr_hrstc, nbr) in next.drain(..) {
             assert!(nbr_cost + nbr_hrstc >= scs_cost);
             // We only need to consider neighbouring nodes if they have the same cost as

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -108,7 +108,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                                    cg: 0};
         let astar_cnds = astar_all(
             start_node,
-            |n, nbrs| {
+            |explore_all, n, nbrs| {
                 // Calculate n's neighbours.
 
                 if n.la_idx > in_la_idx + PORTION_THRESHOLD {
@@ -121,11 +121,15 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                         // Inserts.
                     },
                     _ => {
-                        self.r3is(&n, nbrs);
+                        if explore_all || n.cg > 0 {
+                            self.r3is(&n, nbrs);
+                        }
                         self.r3ir(&n, nbrs);
                     }
                 }
-                self.r3d(&n, nbrs);
+                if explore_all || n.cg > 0 {
+                    self.r3d(&n, nbrs);
+                }
                 self.r3s_n(&n, nbrs);
             },
             |n| {

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -108,35 +108,25 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                                    cg: 0};
         let astar_cnds = astar_all(
             start_node,
-            |n| {
+            |n, nbrs| {
                 // Calculate n's neighbours.
 
                 if n.la_idx > in_la_idx + PORTION_THRESHOLD {
-                    return vec![];
+                    return;
                 }
 
-                let mut nbrs = Vec::new();
                 match n.repairs.val() {
                     Some(&Repair::Delete) => {
                         // We follow Corcheulo et al.'s suggestions and never follow Deletes with
                         // Inserts.
                     },
                     _ => {
-                        self.r3is(&n, &mut nbrs);
-                        self.r3ir(&n, &mut nbrs);
+                        self.r3is(&n, nbrs);
+                        self.r3ir(&n, nbrs);
                     }
                 }
-                self.r3d(&n, &mut nbrs);
-                self.r3s_n(&n, &mut nbrs);
-
-                let v = nbrs.into_iter()
-                            .map(|x| {
-                                    let cf = x.cf;
-                                    let cg = x.cg;
-                                    (cf, cg, x)
-                                 })
-                            .collect::<Vec<(_, _, PathFNode)>>();
-                v
+                self.r3d(&n, nbrs);
+                self.r3s_n(&n, nbrs);
             },
             |n| {
                 // Is n a success node?
@@ -190,7 +180,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + PartialEq> MF<'a, TokId> {
     fn r3is(&self,
             n: &PathFNode,
-            nbrs: &mut Vec<PathFNode>)
+            nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         let top_pstack = *n.pstack.val().unwrap();
         for (&sym, &sym_st_idx) in self.parser.sgraph.edges(top_pstack).iter() {
@@ -226,7 +216,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                         repairs: n_repairs,
                         cf: n.cf.checked_add((self.parser.term_cost)(term_idx) as u32).unwrap(),
                         cg: d};
-                    nbrs.push(nn);
+                    nbrs.push((nn.cf, nn.cg, nn));
                 }
             }
         }
@@ -234,7 +224,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 
     fn r3ir(&self,
             n: &PathFNode,
-            nbrs: &mut Vec<PathFNode>)
+            nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         // This is different than KimYi's r3ir: their r3ir inserts symbols if the dot in a state is not
         // at the end. This is unneeded in our setup (indeed, doing so causes duplicates): all we need
@@ -262,7 +252,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                         repairs: n.repairs.clone(),
                         cf: n.cf,
                         cg: d};
-                    nbrs.push(nn);
+                    nbrs.push((nn.cf, nn.cg, nn));
                 }
             }
         }
@@ -270,7 +260,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
 
     fn r3d(&self,
            n: &PathFNode,
-           nbrs: &mut Vec<PathFNode>)
+           nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         if n.la_idx == self.parser.lexemes.len() {
             return;
@@ -285,13 +275,13 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                                repairs: n_repairs,
                                cf: n.cf.checked_add(cost as u32).unwrap(),
                                cg: d};
-            nbrs.push(nn);
+            nbrs.push((nn.cf, nn.cg, nn));
         }
     }
 
     fn r3s_n(&self,
              n: &PathFNode,
-             nbrs: &mut Vec<PathFNode>)
+             nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         let la_tidx = self.parser.next_tidx(n.la_idx);
         let top_pstack = *n.pstack.val().unwrap();
@@ -306,7 +296,7 @@ impl<'a, TokId: Clone + Copy + Debug + TryFrom<usize> + TryInto<usize> + Partial
                     repairs: n_repairs,
                     cf: n.cf,
                     cg: d};
-                nbrs.push(nn);
+                nbrs.push((nn.cf, nn.cg, nn));
             }
         }
     }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -33,7 +33,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use cactus::Cactus;
-use cfgrammar::{NTIdx, Symbol, TIdx};
+use cfgrammar::{Grammar, NTIdx, Symbol, TIdx};
 use cfgrammar::yacc::YaccGrammar;
 use lrlex::Lexeme;
 use lrtable::{Action, StateGraph, StateTable, StIdx};
@@ -102,6 +102,9 @@ impl<'a, TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usiz
           -> Result<Node<TokId>, (Option<Node<TokId>>, Vec<ParseError<TokId>>)>
       where F: Fn(TIdx) -> u8
     {
+        for i in 0..grm.terms_len() {
+            assert!(term_cost(TIdx::from(i)) > 0);
+        }
         let psr = Parser{rcvry_kind, grm, term_cost: &term_cost, sgraph, stable, lexemes};
         let mut pstack = vec![StIdx::from(0 as u32)];
         let mut tstack: Vec<Node<TokId>> = Vec::new();


### PR DESCRIPTION
This PR contains 4 not-very-related optimisations. Collectively they make my standard examples almost exactly 2x faster. They're also very small!

The first commit is more about saving memory than about performance; the second is a Rust-specific performance hack; the third makes use of the properties of our A* search to avoid searching pointless nodes; and the fourth commit turns on link-time optimisation in rustc (which, IMHO, should probably be on by default).
