### PR TITLE
Simplify the use of num_traits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ name = "lrpar"
 path = "src/lib/mod.rs"
 
 [dependencies]
-getopts = "0.2.15"
 cactus = "1.0.2"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
-lrtable = { git = "http://github.com/softdevteam/lrtable" }
+getopts = "0.2.17"
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
-num-traits = "0.1.41"
+lrtable = { git = "http://github.com/softdevteam/lrtable" }
+num-traits = "0.2.0"
 pathfinding = "0.2.4"
 vob = "0.1.0"
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -30,9 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(step_trait)]
 #![feature(test)]
-#![feature(try_from)]
 
 extern crate cactus;
 extern crate cfgrammar;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,28 +30,24 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(try_from)]
+extern crate cfgrammar;
+extern crate getopts;
+extern crate lrlex;
+extern crate lrtable;
+extern crate lrpar;
+extern crate num_traits;
 
-use std::convert::TryFrom;
 use std::{env, process};
 use std::fs::File;
 use std::io::{Read, stderr, Write};
 use std::path::Path;
 
-extern crate getopts;
 use getopts::Options;
-
-extern crate cfgrammar;
 use cfgrammar::yacc::{yacc_grm, YaccKind};
-
-extern crate lrlex;
 use lrlex::build_lex;
-
-extern crate lrtable;
 use lrtable::{Minimiser, from_yacc};
-
-extern crate lrpar;
 use lrpar::parser::{parse_rcvry, ParseRepair, RecoveryKind};
+use num_traits::ToPrimitive;
 
 fn usage(prog: &str, msg: &str) -> ! {
     let path = Path::new(prog);
@@ -138,7 +134,7 @@ fn main() {
 
     {
         let rule_ids = grm.terms_map().iter()
-                                      .map(|(&n, &i)| (n, u16::try_from(usize::from(i)).unwrap()))
+                                      .map(|(&n, &i)| (n, usize::from(i).to_u16().unwrap()))
                                       .collect();
         let (missing_from_lexer, missing_from_parser) = lexerdef.set_rule_ids(&rule_ids);
         if let Some(tokens) = missing_from_parser {


### PR DESCRIPTION
Because we don't know the type of a TokId, we have to use traits and constraints. This led to lots ugliness like:

```
TokId: Clone + Copy + Debug + PartialEq + TryFrom<usize> + TryInto<usize>
```

This PR makes greater use of the num_traits crate. The above becomes:

```
TokId: PrimInt + Unsigned
```

This also allows us to ditch try_from, which still hasn't stabilised in Rust and which is on the laborious side. Things like:

```
u32::try_from(x).unwrap();
```

become:

```
x.to_u32().unwrap();
```

It's not a huge difference, but given that we also save on the trait constraints, it seems a worthwhile change.