### PR TITLE
Reimplement Corchuelo in the style of MF, and also fix the shift() function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ path = "src/lib/mod.rs"
 cactus = "1.0.2"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
 getopts = "0.2.17"
+indexmap = "0.4.1"
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
 num-traits = "0.2.0"
-pathfinding = "0.2.4"
 vob = "0.1.0"
 
 [profile.release]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -34,10 +34,10 @@
 
 extern crate cactus;
 extern crate cfgrammar;
+#[macro_use] extern crate indexmap;
 extern crate lrlex;
 extern crate lrtable;
 extern crate num_traits;
-extern crate pathfinding;
 extern crate test;
 extern crate vob;
 

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -162,9 +162,8 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
                 None => {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
-                                             RecoveryKind::Corchuelo => corchuelo::recoverer(),
-                                             RecoveryKind::MF =>
-                                                 mf::recoverer(self),
+                                             RecoveryKind::Corchuelo => corchuelo::recoverer(self),
+                                             RecoveryKind::MF => mf::recoverer(self),
                                          });
                     }
 


### PR DESCRIPTION
Reimplement Corchuelo in the style of MF, and also fix the shift() function.

Our implementation of the Corchuelo recoverer was in a much different (and worse) style to the MF recoverer. This commit homogenises the styles, generally by copying code from MF with the minimal necessary changes.

This also seems the right time to finally bite the bullet and fix one of Corchuelo's most glaring errors: the forward move (what we call the "insert") rule is broken. Because it always tries to generate the maximum possible number of shifts, it misses out some minimal repairs (as KimYi state, but don't explain). This commit thus changes the shift rule to only find one shift at a time. This means that the Corchuelo recoverer can now find all of the same repairs as the MF recoverer.

Because the Corchuelo recoverer creates duplicate nodes in its search, the astar_all function isn't quite what we want. For what of a better term, I've implemented a Dijkstra function. This weeds out duplicates in the todo list. This is clearly less powerful than remembering all previously seen nodes, but implementing that was about 10% slower (possibly just because of the extra memory needed).