### PR TITLE
Switchable recoverers

### DIFF
--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -164,6 +164,14 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
                         recoverer = Some(match self.rcvry_kind {
                                              RecoveryKind::Corchuelo => corchuelo::recoverer(self),
                                              RecoveryKind::MF => mf::recoverer(self),
+                                             RecoveryKind::None => {
+                                                let la_lexeme = self.next_lexeme(la_idx);
+                                                errors.push(ParseError{state_idx: st,
+                                                                       lexeme_idx: la_idx,
+                                                                       lexeme: la_lexeme,
+                                                                       repairs: vec![]});
+                                                return false;
+                                             }
                                          });
                     }
 
@@ -293,7 +301,8 @@ pub trait Recoverer<TokId: PrimInt + Unsigned> {
 
 pub enum RecoveryKind {
     Corchuelo,
-    MF
+    MF,
+    None
 }
 
 /// Parse the lexemes. On success return a parse tree. On failure, return a parse tree (if all the

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,7 @@ fn main() {
                     println!("  {}", out.join(", "));
                 }
             }
+            process::exit(1);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,10 @@ fn main() {
             }
             for e in errs {
                 let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                if e.repairs().is_empty() {
+                    println!("Error detected at line {} col {}. No repairs found.", line, col);
+                    continue;
+                }
                 println!("Error detected at line {} col {}. Amongst the valid repairs are:", line, col);
                 for repair in e.repairs() {
                     let mut lex_idx = e.lexeme_idx();

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,9 @@ fn usage(prog: &str, msg: &str) -> ! {
     if !msg.is_empty() {
         writeln!(&mut stderr(), "{}", msg).ok();
     }
-    writeln!(&mut stderr(), "Usage: {} [-y <eco|original>] <lexer.l> <parser.y> <input file>", leaf).ok();
+    writeln!(&mut stderr(),
+             "Usage: {} [-r <corchuelo|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
+             leaf).ok();
     process::exit(1);
 }
 
@@ -80,6 +82,9 @@ fn main() {
     let prog = &args[0];
     let matches = match Options::new()
                                 .optflag("h", "help", "")
+                                .optopt("r", "recoverer",
+                                        "Recoverer to be used (default: MF)",
+                                        "Corchuelo|MF|None")
                                 .optopt("y", "yaccvariant",
                                         "Yacc variant to be parsed (default: Original)",
                                         "Original|Eco")
@@ -91,6 +96,18 @@ fn main() {
     if matches.opt_present("h") {
         usage(prog, "");
     }
+
+    let recoverykind = match matches.opt_str("r") {
+        None => RecoveryKind::MF,
+        Some(s) => {
+            match &*s.to_lowercase() {
+                "corchuelo" => RecoveryKind::Corchuelo,
+                "mf" => RecoveryKind::MF,
+                "none" => RecoveryKind::None,
+                _ => usage(prog, &format!("Unknown recoverer '{}'.", s))
+            }
+        }
+    };
 
     let yacckind = match matches.opt_str("y") {
         None => YaccKind::Original,
@@ -164,7 +181,7 @@ fn main() {
     let lexer = lexerdef.lexer(&input);
     let lexemes = lexer.lexemes().unwrap();
     let term_cost = |_| 1; // Cost of inserting/deleting a terminal
-    match parse_rcvry::<u16, _>(RecoveryKind::MF, &grm, &term_cost, &sgraph, &stable, &lexemes) {
+    match parse_rcvry::<u16, _>(recoverykind, &grm, &term_cost, &sgraph, &stable, &lexemes) {
         Ok(pt) => println!("{}", pt.pp(&grm, &input)),
         Err((o_pt, errs)) => {
             match o_pt {


### PR DESCRIPTION
This PR first adds a "none" recoverer (so one can switch recovery off) and then exposes that via a `-r` switch to the outside world. There are then a couple of "cosmetic" fixes, including returning non-zero to the outside world on an unsuccessful parse (which I should have added ages ago, as it's very useful).

A quick example:

```
$ target/debug/lrpar -r none -y eco java.l java.y bad.java

Unable to repair input sufficiently to produce parse tree.

Error detected at line 2 col 12. No repairs found.
$ echo $?
1
```