### PR TITLE
Merge compatible nodes

### DIFF
--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -33,7 +33,7 @@
 use std::hash::Hash;
 use std::fmt::Debug;
 
-use indexmap::IndexSet;
+use indexmap::map::{Entry, IndexMap};
 
 /// Starting at `start_node`, return, in arbitrary order, all least-cost success nodes.
 ///
@@ -132,16 +132,21 @@ pub(crate) fn astar_all<N, FN, FS>(start_node: N,
 /// The name of this function isn't entirely accurate: this isn't Dijkstra's original algorithm or
 /// one of its well-known variants. However, unlike the astar_all function it doesn't expect a
 /// heuristic and it also filters out some duplicates.
-pub(crate) fn dijkstra<N, FN, FS>(start_node: N,
-                                  neighbours: FN,
-                                  success: FS)
-                               -> Vec<N>
-                            where N: Debug + Clone + Hash + Eq + PartialEq,
-                                  FN: Fn(bool, &N, &mut Vec<(u32, N)>),
-                                  FS: Fn(&N) -> bool,
+pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
+                                      neighbours: FN,
+                                      merge: FM,
+                                      success: FS)
+                                   -> Vec<N>
+                                where N: Debug + Clone + Hash + Eq + PartialEq,
+                                      FN: Fn(bool, &N, &mut Vec<(u32, N)>),
+                                      FM: Fn(&mut N, N),
+                                      FS: Fn(&N) -> bool,
 {
     let mut scs_nodes = Vec::new();
-    let mut todo: Vec<IndexSet<N>> = vec![indexset![start_node]];
+    // todo is a map from "original node" to "merged node". We never change "original node", but,
+    // as we find compatible repairs, continually update merged node. This means that when we pop
+    // things off the todo we *must* use "merged node" as our node to work with.
+    let mut todo: Vec<IndexMap<N, N>> = vec![indexmap![start_node.clone() => start_node]];
     let mut c: u32 = 0;
     let mut next = Vec::new();
     loop {
@@ -153,7 +158,7 @@ pub(crate) fn dijkstra<N, FN, FS>(start_node: N,
             continue;
         }
 
-        let n = todo[c as usize].pop().unwrap();
+        let n = todo[c as usize].pop().unwrap().1;
         if success(&n) {
             scs_nodes.push(n);
             break;
@@ -163,15 +168,18 @@ pub(crate) fn dijkstra<N, FN, FS>(start_node: N,
         for (nbr_cost, nbr) in next.drain(..) {
             let off = nbr_cost as usize;
             for _ in todo.len()..off + 1 {
-                todo.push(IndexSet::new());
+                todo.push(IndexMap::new());
             }
-            todo[off].insert(nbr);
+            match todo[off].entry(nbr.clone()) {
+                Entry::Vacant(e) => { e.insert(nbr); },
+                Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+            }
         }
     }
 
     let mut scs_todo = todo.drain(c as usize..c as usize + 1).nth(0).unwrap();
     while !scs_todo.is_empty() {
-        let n = scs_todo.pop().unwrap();
+        let n = scs_todo.pop().unwrap().1;
         if success(&n) {
             scs_nodes.push(n);
             continue;
@@ -179,7 +187,10 @@ pub(crate) fn dijkstra<N, FN, FS>(start_node: N,
         neighbours(false, &n, &mut next);
         for (nbr_cost, nbr) in next.drain(..) {
             if nbr_cost == c {
-                scs_todo.insert(nbr);
+                match scs_todo.entry(nbr.clone()) {
+                    Entry::Vacant(e) => { e.insert(nbr); },
+                    Entry::Occupied(mut e) => { merge(&mut e.get_mut(), nbr); }
+                }
             }
         }
     }

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -115,15 +115,15 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for MF<'a, TokId>
                     },
                     _ => {
                         if explore_all || n.cg > 0 {
-                            self.r3is(n, nbrs);
+                            self.insert(n, nbrs);
                         }
-                        self.r3ir(n, nbrs);
+                        self.reduce(n, nbrs);
                     }
                 }
                 if explore_all || n.cg > 0 {
-                    self.r3d(n, nbrs);
+                    self.delete(n, nbrs);
                 }
-                self.r3s_n(n, nbrs);
+                self.shift(n, nbrs);
             },
             |n| {
                 // Is n a success node?
@@ -174,9 +174,9 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for MF<'a, TokId>
 }
 
 impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
-    fn r3is(&self,
-            n: &PathFNode,
-            nbrs: &mut Vec<(u32, u32, PathFNode)>)
+    fn insert(&self,
+              n: &PathFNode,
+              nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         let top_pstack = *n.pstack.val().unwrap();
         for (&sym, &sym_st_idx) in self.parser.sgraph.edges(top_pstack).iter() {
@@ -218,9 +218,9 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         }
     }
 
-    fn r3ir(&self,
-            n: &PathFNode,
-            nbrs: &mut Vec<(u32, u32, PathFNode)>)
+    fn reduce(&self,
+              n: &PathFNode,
+              nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         // This is different than KimYi's r3ir: their r3ir inserts symbols if the dot in a state is not
         // at the end. This is unneeded in our setup (indeed, doing so causes duplicates): all we need
@@ -254,9 +254,9 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         }
     }
 
-    fn r3d(&self,
-           n: &PathFNode,
-           nbrs: &mut Vec<(u32, u32, PathFNode)>)
+    fn delete(&self,
+              n: &PathFNode,
+              nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         if n.la_idx == self.parser.lexemes.len() {
             return;
@@ -275,7 +275,7 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         }
     }
 
-    fn r3s_n(&self,
+    fn shift(&self,
              n: &PathFNode,
              nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {


### PR DESCRIPTION
This PR merges together compatible nodes, helping to substantially reduce the search space. It gives at least a 2x speedup on pretty much everything I've tried it on. After a trivial renaming commit, the heart of this PR is https://github.com/softdevteam/lrpar/commit/f1305900dcc5f8f9270fb66aefae5c336a7eebcb which applies the merging idea to the Corchuelo recoverer -- and its commit message explains things in (I hope) plenty of detail. The third commit simply ports the same idea to the MF recoverer.