### PR TITLE
Add a recovery timeout

### DIFF
--- a/src/lib/astar.rs
+++ b/src/lib/astar.rs
@@ -51,7 +51,7 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
                                        success: FS)
                                     -> Vec<N>
                                  where N: Debug + Clone + Hash + Eq + PartialEq,
-                                       FN: Fn(bool, &N, &mut Vec<(u32, u32, N)>),
+                                       FN: Fn(bool, &N, &mut Vec<(u32, u32, N)>) -> bool,
                                        FM: Fn(&mut N, N),
                                        FS: Fn(&N) -> bool,
 {
@@ -89,7 +89,9 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
             break;
         }
 
-        neighbours(true, &n, &mut next);
+        if !neighbours(true, &n, &mut next) {
+            return Vec::new();
+        }
         for (nbr_cost, nbr_hrstc, nbr) in next.drain(..) {
             assert!(nbr_cost + nbr_hrstc >= c);
             let off = nbr_cost.checked_add(nbr_hrstc).unwrap() as usize;
@@ -117,7 +119,9 @@ pub(crate) fn astar_all<N, FN, FM, FS>(start_node: N,
             scs_nodes.push(n);
             continue;
         }
-        neighbours(false, &n, &mut next);
+        if !neighbours(false, &n, &mut next) {
+            return Vec::new();
+        }
         for (nbr_cost, nbr_hrstc, nbr) in next.drain(..) {
             assert!(nbr_cost + nbr_hrstc >= c);
             // We only need to consider neighbouring nodes if they have the same cost as
@@ -149,7 +153,7 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
                                       success: FS)
                                    -> Vec<N>
                                 where N: Debug + Clone + Hash + Eq + PartialEq,
-                                      FN: Fn(bool, &N, &mut Vec<(u32, N)>),
+                                      FN: Fn(bool, &N, &mut Vec<(u32, N)>) -> bool,
                                       FM: Fn(&mut N, N),
                                       FS: Fn(&N) -> bool,
 {
@@ -172,7 +176,9 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
             break;
         }
 
-        neighbours(true, &n, &mut next);
+        if !neighbours(true, &n, &mut next) {
+            return Vec::new();
+        }
         for (nbr_cost, nbr) in next.drain(..) {
             let off = nbr_cost as usize;
             for _ in todo.len()..off + 1 {
@@ -192,7 +198,9 @@ pub(crate) fn dijkstra<N, FM, FN, FS>(start_node: N,
             scs_nodes.push(n);
             continue;
         }
-        neighbours(false, &n, &mut next);
+        if !neighbours(false, &n, &mut next) {
+            return Vec::new();
+        }
         for (nbr_cost, nbr) in next.drain(..) {
             if nbr_cost == c {
                 match scs_todo.entry(nbr.clone()) {

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -32,6 +32,7 @@
 
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
+use std::time::Instant;
 
 use cactus::Cactus;
 use cfgrammar::{Symbol, TIdx};
@@ -141,6 +142,7 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
 
 {
     fn recover(&self,
+               finish_by: Instant,
                parser: &Parser<TokId>,
                in_la_idx: usize,
                in_pstack: &mut Vec<StIdx>,
@@ -177,8 +179,12 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
             |explore_all, n, nbrs| {
                 // Calculate n's neighbours.
 
+                if Instant::now() >= finish_by {
+                    return false;
+                }
+
                 if n.la_idx > in_la_idx + PORTION_THRESHOLD {
-                    return;
+                    return true;
                 }
 
                 match n.last_repair() {
@@ -196,6 +202,7 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
                     self.delete(n, nbrs);
                 }
                 self.shift(n, nbrs);
+                true
             },
             |old, new| {
                 // merge new_n into old_n


### PR DESCRIPTION
Corchuelo have heuristics to know "when to stop" -- unfortunately they don't work well in edge cases as they're based on the number of tokens examined. For example, on the Java grammar, it's possible to construct inputs that have massive search spaces, even with only a few tokens involved, and that take tens of minutes to complete.

This PR adds a simple timeout facility to recoverers: after a fixed amount of time (0.5s) the recoverer simply gives up. This is, in one way, very dumb, but it deals well with the user expectation that recovery won't continue indefinitely. The check is put into the "neighbours" function, which is expected to regularly check the timeout. This means that we check pretty often, but not so often as to be ridiculous. It also keeps the API fairly simple.

A note of warning: on some platforms, there appears to be a codegen bug. In debug mode, this PR works fine. In release mode (on 2 of the 3 machines I have access to), the timeout doesn't work. I don't really know why. It is, of course, quite possible that I've made a crass mistake, so please check to see if I've done something obviously stupid. But, because the problem only occurs in release mode, I suspect it's a buggy optimisation somewhere in rustc or LLVM...