### PR TITLE
Add tests, and a fix, derived from Cerecke's PhD thesis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ getopts = "0.2.17"
 indexmap = "0.4.1"
 lrlex = { git = "http://github.com/softdevteam/lrlex" }
 lrtable = { git = "http://github.com/softdevteam/lrtable" }
-num-traits = "0.2.0"
-vob = "0.1.0"
+num-traits = "0.2.1"
+vob = "1.0.0"
 
 [profile.release]
 opt-level = 3

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -35,7 +35,7 @@ use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
 use cactus::Cactus;
-use cfgrammar::{Symbol, TIdx};
+use cfgrammar::TIdx;
 use lrlex::Lexeme;
 use lrtable::{Action, StIdx};
 use num_traits::{PrimInt, Unsigned};

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -267,41 +267,43 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
               nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
         let top_pstack = *n.pstack.val().unwrap();
-        for (&sym, &sym_st_idx) in self.parser.sgraph.edges(top_pstack).iter() {
-            if let Symbol::Term(term_idx) = sym {
-                if term_idx == self.parser.grm.eof_term_idx() {
-                    continue;
-                }
+        for t_idx in self.parser.stable.state_shifts(top_pstack) {
+            if t_idx == self.parser.grm.eof_term_idx() {
+                continue;
+            }
 
-                let n_repairs = n.repairs.child(RepairMerge::Repair(Repair::InsertTerm(term_idx)));
-                if let Some(d) = self.dyn_dist(&n_repairs, sym_st_idx, n.la_idx) {
-                    if let Some(Repair::Shift) = n.last_repair() {
-                        debug_assert!(n.la_idx > 0);
-                        // If we're about to insert term T and the next terminal in the user's
-                        // input is T, we could potentially end up with two similar repair
-                        // sequences:
-                        //   Insert T, Shift
-                        //   Shift, Insert T
-                        // From a user's perspective, both of those are equivalent. From our point
-                        // of view, the duplication is inefficient. We prefer the former sequence
-                        // because we want to find PARSE_AT_LEAST consecutive shifts. At this
-                        // point, we see if we're about to Insert T after a Shift of T and, if so,
-                        // avoid doing so.
-                        let prev_tidx = self.parser.next_tidx(n.la_idx - 1);
-                        if prev_tidx == term_idx {
-                            continue;
-                        }
+            let t_st_idx = match self.parser.stable.action(top_pstack, t_idx).unwrap() {
+                Action::Shift(s_idx) => s_idx,
+                _ => unreachable!()
+            };
+            let n_repairs = n.repairs.child(RepairMerge::Repair(Repair::InsertTerm(t_idx)));
+            if let Some(d) = self.dyn_dist(&n_repairs, t_st_idx, n.la_idx) {
+                if let Some(Repair::Shift) = n.last_repair() {
+                    debug_assert!(n.la_idx > 0);
+                    // If we're about to insert term T and the next terminal in the user's
+                    // input is T, we could potentially end up with two similar repair
+                    // sequences:
+                    //   Insert T, Shift
+                    //   Shift, Insert T
+                    // From a user's perspective, both of those are equivalent. From our point
+                    // of view, the duplication is inefficient. We prefer the former sequence
+                    // because we want to find PARSE_AT_LEAST consecutive shifts. At this
+                    // point, we see if we're about to Insert T after a Shift of T and, if so,
+                    // avoid doing so.
+                    let prev_tidx = self.parser.next_tidx(n.la_idx - 1);
+                    if prev_tidx == t_idx {
+                        continue;
                     }
-
-                    assert!(n.cg == 0 || d >= n.cg - (self.parser.term_cost)(term_idx) as u32);
-                    let nn = PathFNode{
-                        pstack: n.pstack.child(sym_st_idx),
-                        la_idx: n.la_idx,
-                        repairs: n_repairs,
-                        cf: n.cf.checked_add((self.parser.term_cost)(term_idx) as u32).unwrap(),
-                        cg: d};
-                    nbrs.push((nn.cf, nn.cg, nn));
                 }
+
+                assert!(n.cg == 0 || d >= n.cg - (self.parser.term_cost)(t_idx) as u32);
+                let nn = PathFNode{
+                    pstack: n.pstack.child(t_st_idx),
+                    la_idx: n.la_idx,
+                    repairs: n_repairs,
+                    cf: n.cf.checked_add((self.parser.term_cost)(t_idx) as u32).unwrap(),
+                    cg: d};
+                nbrs.push((nn.cf, nn.cg, nn));
             }
         }
     }
@@ -310,16 +312,9 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
               n: &PathFNode,
               nbrs: &mut Vec<(u32, u32, PathFNode)>)
     {
-        // This is different than KimYi's r3ir: their r3ir inserts symbols if the dot in a state is not
-        // at the end. This is unneeded in our setup (indeed, doing so causes duplicates): all we need
-        // to do is reduce states where the dot is at the end.
-
         let top_pstack = *n.pstack.val().unwrap();
-        for &(p_idx, sym_off) in self.parser.sgraph.closed_state(top_pstack).items.keys() {
-            if usize::from(sym_off) != self.parser.grm.prod(p_idx).len() {
-                continue;
-            }
-
+        for p_idx in self.parser.stable.core_reduces(top_pstack) {
+            let sym_off = self.parser.grm.prod(p_idx).len();
             let nt_idx = self.parser.grm.prod_to_nonterm(p_idx);
             let mut qi_minus_alpha = n.pstack.clone();
             for _ in 0..usize::from(sym_off) {
@@ -733,7 +728,7 @@ impl Dist {
                 }
 
                 // The second phase takes into account reductions and gotos.
-                for st_idx in goto_states[i].iter_set_bits() {
+                for st_idx in goto_states[i].iter_set_bits(..) {
                     for j in 0..terms_len {
                         let this_off = i * terms_len + j;
                         let other_off = st_idx * terms_len + j;
@@ -805,14 +800,14 @@ impl Dist {
                 prev.set(i, true);
                 for _ in 0..prod.len() {
                     next.set_all(false);
-                    for st_idx in prev.iter_set_bits() {
+                    for st_idx in prev.iter_set_bits(..) {
                         next.or(&rev_edges[st_idx]);
                     }
                     mem::swap(&mut prev, &mut next);
                 }
 
                 // From the reduction states, find all the goto states.
-                for st_idx in prev.iter_set_bits() {
+                for st_idx in prev.iter_set_bits(..) {
                     if let Some(goto_st_idx) = stable.goto(StIdx::from(st_idx), nt_idx) {
                         goto_states[i].set(usize::from(goto_st_idx), true);
                     }
@@ -1454,7 +1449,7 @@ S: 'a' S 'b'
 
     #[test]
     fn test_cerecke_lr2() {
-        // Example taken from p67 of Locally least-cost error repair in LR parsers, Carl Cerecke
+        // Example taken from p54 of Locally least-cost error repair in LR parsers, Carl Cerecke
         let lexs = "%%
 a a
 b b
@@ -1473,15 +1468,20 @@ B: 'a'
 A: 'b';
 ";
 
-        // If we only use a statetable, this example is unrecoverable. Because we currently use a
-        // stategraph we do find repairs, even though the parser can't recognise the resulting
-        // input...
+        do_parse(RecoveryKind::MF, &lexs, &grms, &"acd").1.unwrap();
+        do_parse(RecoveryKind::MF, &lexs, &grms, &"bce").1.unwrap();
         let us = "ce";
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);
         let (_, errs) = pr.unwrap_err();
         check_all_repairs(&grm,
                           errs[0].repairs(),
-                          &vec!["Insert \"a\"", "Insert \"b\""]);
+                          &vec!["Insert \"b\""]);
+        let us = "cd";
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);
+        let (_, errs) = pr.unwrap_err();
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Insert \"a\""]);
     }
 
     #[test]

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -1453,6 +1453,38 @@ S: 'a' S 'b'
     }
 
     #[test]
+    fn test_cerecke_lr2() {
+        // Example taken from p67 of Locally least-cost error repair in LR parsers, Carl Cerecke
+        let lexs = "%%
+a a
+b b
+c c
+d d
+e e
+";
+
+        let grms = "%start S
+%%
+S: A 'c' 'd'
+ | B 'c' 'e';
+A: 'a';
+B: 'a'
+ | 'b';
+A: 'b';
+";
+
+        // If we only use a statetable, this example is unrecoverable. Because we currently use a
+        // stategraph we do find repairs, even though the parser can't recognise the resulting
+        // input...
+        let us = "ce";
+        let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);
+        let (_, errs) = pr.unwrap_err();
+        check_all_repairs(&grm,
+                          errs[0].repairs(),
+                          &vec!["Insert \"a\"", "Insert \"b\""]);
+    }
+
+    #[test]
     fn test_counting_shifts() {
         let mut c = Cactus::new();
         assert_eq!(ends_with_parse_at_least_shifts(&c), false);


### PR DESCRIPTION
NB: Needs https://github.com/softdevteam/lrtable/pull/88 to be merged first.

Cerecke's thesis is a goldmine of edge case examples. One of them shows up a problem which I sort-of knew we had, but which turned out to be much worse than I thought. Because (like Kim & Yi) we use the stategraph to guide repairs, it's obvious that, for grammars that have shift/reduce or reduce/reduce errors, we would find different repairs than the statetable. I assumed that we would simply find a superset of repairs, but I was wrong: Cerecke has an example that shows we produce repairs which are a) not the lowest possible cost (!) b) can't be parsed by the statetable. 

After adding a couple of tests, this PR thus fixes this problem in https://github.com/softdevteam/lrpar/commit/09a567bbd13e729864028ea31ae3205e85ee5953. As a happy bonus this means that (apart from the `Dist` calculation) we no longer have any reliance on the stategraph. Since `Dist` can be calculated at compile-time, this means that the MF recoverer does not, ultimately, need to keep the stategraph around at run-time. That will, one day, enable it to take up less memory when it generates static grammar tables (a la Yacc).