### PR TITLE
Better timeouts

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -249,7 +249,8 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
 
         let full_rprs = self.collect_repairs(astar_cnds);
         let smpl_rprs = self.simplify_repairs(full_rprs);
-        let rnk_rprs = self.rank_cnds(in_la_idx,
+        let rnk_rprs = self.rank_cnds(finish_by,
+                                      in_la_idx,
                                       &start_cactus_pstack,
                                       smpl_rprs);
         let (la_idx, mut rpr_pstack) = apply_repairs(parser,
@@ -476,6 +477,7 @@ impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
     /// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
     /// ordering is non-deterministic.
     fn rank_cnds(&self,
+                 finish_by: Instant,
                  in_la_idx: usize,
                  start_pstack: &Cactus<StIdx>,
                  in_cnds: Vec<Vec<ParseRepair>>)
@@ -499,9 +501,13 @@ impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
         todo.resize(cnds.len(), true);
         let mut remng = cnds.len(); // Remaining items in todo
         let mut i = 0;
-        while i < TRY_PARSE_AT_MOST && remng > 1 {
+        'b: while i < TRY_PARSE_AT_MOST && remng > 1 {
             let mut j = 0;
             while j < todo.len() {
+                if Instant::now() >= finish_by {
+                   break 'b;
+                }
+
                 if !todo[j] {
                     j += 1;
                     continue;

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -31,7 +31,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+use std::iter::FromIterator;
 use std::time::Instant;
 
 use cactus::Cactus;
@@ -448,19 +450,12 @@ impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
         }
 
         // The simplifications above can mean that we now end up with equivalent repairs. Remove
-        // duplicates.
-
-        let mut i = 0;
-        while i < all_rprs.len() {
-            let mut j = i + 1;
-            while j < all_rprs.len() {
-                if all_rprs[i] == all_rprs[j] {
-                    all_rprs.remove(j);
-                } else {
-                    j += 1;
-                }
-            }
-            i += 1;
+        // duplicates by creating a temporary HashSet. This is a hack, but since Vec<Repair> isn't
+        // sortable, this is the easiest, and fastet way we have of getting things done.
+        {
+            let tmp: HashSet<Vec<Repair>> = HashSet::from_iter(all_rprs);
+            all_rprs = tmp.into_iter()
+                          .collect::<Vec<Vec<Repair>>>();
         }
 
         all_rprs.iter()

--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -436,15 +436,13 @@ impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
                      -> Vec<Vec<ParseRepair>>
     {
         for i in 0..all_rprs.len() {
-            {
-                // Remove shifts from the end of repairs
-                let mut rprs = &mut all_rprs[i];
-                while !rprs.is_empty() {
-                    if let Repair::Shift = rprs[rprs.len() - 1] {
-                        rprs.pop();
-                    } else {
-                        break;
-                    }
+            // Remove shifts from the end of repairs
+            let mut rprs = &mut all_rprs[i];
+            while !rprs.is_empty() {
+                if let Repair::Shift = rprs[rprs.len() - 1] {
+                    rprs.pop();
+                } else {
+                    break;
                 }
             }
         }

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -240,7 +240,8 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for MF<'a, TokId>
 
         let full_rprs = self.collect_repairs(astar_cnds);
         let smpl_rprs = self.simplify_repairs(full_rprs);
-        let rnk_rprs = self.rank_cnds(in_la_idx,
+        let rnk_rprs = self.rank_cnds(finish_by,
+                                      in_la_idx,
                                       &start_cactus_pstack,
                                       smpl_rprs);
         let (la_idx, mut rpr_pstack) = apply_repairs(parser,
@@ -476,6 +477,7 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
     /// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
     /// ordering is non-deterministic.
     fn rank_cnds(&self,
+                 finish_by: Instant,
                  in_la_idx: usize,
                  start_pstack: &Cactus<StIdx>,
                  in_cnds: Vec<Vec<ParseRepair>>)
@@ -499,9 +501,13 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         todo.resize(cnds.len(), true);
         let mut remng = cnds.len(); // Remaining items in todo
         let mut i = 0;
-        while i < TRY_PARSE_AT_MOST && remng > 1 {
+        'b: while i < TRY_PARSE_AT_MOST && remng > 1 {
             let mut j = 0;
             while j < todo.len() {
+                if Instant::now() >= finish_by {
+                    break 'b;
+                }
+
                 if !todo[j] {
                     j += 1;
                     continue;

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -31,7 +31,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
+use std::iter::FromIterator;
 use std::mem;
 use std::time::Instant;
 
@@ -448,19 +450,12 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         }
 
         // The simplifications above can mean that we now end up with equivalent repairs. Remove
-        // duplicates.
-
-        let mut i = 0;
-        while i < all_rprs.len() {
-            let mut j = i + 1;
-            while j < all_rprs.len() {
-                if all_rprs[i] == all_rprs[j] {
-                    all_rprs.remove(j);
-                } else {
-                    j += 1;
-                }
-            }
-            i += 1;
+        // duplicates by creating a temporary HashSet. This is a hack, but since Vec<Repair> isn't
+        // sortable, this is the easiest, and fastet way we have of getting things done.
+        {
+            let tmp: HashSet<Vec<Repair>> = HashSet::from_iter(all_rprs);
+            all_rprs = tmp.into_iter()
+                          .collect::<Vec<Vec<Repair>>>();
         }
 
         all_rprs.iter()

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -436,15 +436,13 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
                      -> Vec<Vec<ParseRepair>>
     {
         for i in 0..all_rprs.len() {
-            {
-                // Remove shifts from the end of repairs
-                let mut rprs = &mut all_rprs[i];
-                while !rprs.is_empty() {
-                    if let Repair::Shift = rprs[rprs.len() - 1] {
-                        rprs.pop();
-                    } else {
-                        break;
-                    }
+            // Remove shifts from the end of repairs
+            let mut rprs = &mut all_rprs[i];
+            while !rprs.is_empty() {
+                if let Repair::Shift = rprs[rprs.len() - 1] {
+                    rprs.pop();
+                } else {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
This is really two useful commits (the first and third) with a cosmetic (the second). First, when we have bucketloads of successful repair sequences (occasionally we can generate hundreds of thousands), our simplification "algorithm" (a bubblesort in disguise) was horribly slow: https://github.com/softdevteam/lrpar/commit/737701bdc1813804f8e19c9f489344b59c90a0ed fixes this. Second, when we have that many repair sequences, ranking them can be quite slow too, so use the timeout for that too: https://github.com/softdevteam/lrpar/commit/48e3628e50165345f8b2fbe988dc3265129f3600 fixes this.