### PR TITLE
Sort repairs consistently, as far as we are able.

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -30,7 +30,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
@@ -517,12 +516,10 @@ impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
         // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
         // intuition that "repairs which affect the shortest part of the string are preferable").
         cnds.sort_unstable_by(|x, y| {
-            match y.1.cmp(&x.1) {
-                Ordering::Equal => {
-                    x.2.len().cmp(&y.2.len())
-                },
-                a => a
-            }
+            y.1.cmp(&x.1)
+               .then_with(|| x.2.len()
+                                .cmp(&y.2.len()))
+               .then_with(|| x.2.cmp(&y.2))
         });
 
         cnds.into_iter()

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -30,7 +30,6 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
@@ -517,12 +516,10 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
         // intuition that "repairs which affect the shortest part of the string are preferable").
         cnds.sort_unstable_by(|x, y| {
-            match y.1.cmp(&x.1) {
-                Ordering::Equal => {
-                    x.2.len().cmp(&y.2.len())
-                },
-                a => a
-            }
+            y.1.cmp(&x.1)
+               .then_with(|| x.2.len()
+                                .cmp(&y.2.len()))
+               .then_with(|| x.2.cmp(&y.2))
         });
 
         cnds.into_iter()

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -348,7 +348,7 @@ pub fn parse_rcvry
 
 /// After a parse error is encountered, the parser attempts to find a way of recovering. Each entry
 /// in the sequence of repairs is represented by a `ParseRepair`.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum ParseRepair {
     /// Insert a `Symbol::Term`.
     Insert(TIdx),


### PR DESCRIPTION
https://github.com/softdevteam/cfgrammar/pull/25 needs to be merged first, then the tests here will need kicking.

Previously, two equally ranked repair sequences, of the same cost, and the same length would appear in a random order in the list of repair sequences. This can be frustrating when comparing error recovery algorithms, where one repair sequence is (far further forward in the file) better than another.

This commit reduces the randomness by sorting on the ParseRepair struct itself as a third case, though it can't avoid it completely. For example, terminals are non-deterministically assigned different numbers on each grammar generation, so sometimes "Insert a" will be "InsertTerm(0)" and sometimes "InsertTerm(1)" and fixing that will involve a non-trivial API fix.