### PR TITLE
Remove the PORTION_THRESHOLD limit.

### DIFF
--- a/src/lib/corchuelo.rs
+++ b/src/lib/corchuelo.rs
@@ -46,7 +46,6 @@ use mf::apply_repairs;
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
-const PORTION_THRESHOLD: usize = 5; // N_t in Corchuelo et al.
 const TRY_PARSE_AT_MOST: usize = 250;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -179,10 +178,6 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
 
                 if Instant::now() >= finish_by {
                     return false;
-                }
-
-                if n.la_idx > in_la_idx + PORTION_THRESHOLD {
-                    return true;
                 }
 
                 match n.last_repair() {

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -570,22 +570,4 @@ Call: 'ID' 'OPEN_BRACKET' 'CLOSE_BRACKET';";
         let err_tok_id = usize::from(grm.term_idx("ID").unwrap()).to_u16().unwrap();
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
      }
-
-    #[test]
-    fn no_tree_if_cant_be_repaired() {
-        let lexs = "%%
-a A
-b B
-";
-        let grms = "%start S
-%%
-S: 'A' 'A' 'B';
-";
-
-        let us = "aaaaaaaaaaaaaab";
-        let (_, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);
-        assert!(pr.is_err() && pr.unwrap_err().0.is_none());
-        let (_, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, &us);
-        assert!(pr.is_err() && pr.unwrap_err().0.is_none());
-    }
 }


### PR DESCRIPTION
The time-based limit we now have is far more effective and less confusing, so simply remove this entirely. It also had some weird, unintended, effects. On the expression grammar, we would find non-minimal cost repair sequences for inputs that were on the  ORTION_THRESHOLD limit (e.g. "(+++++)") because we would stop searching nodes of >= PORTION_THRESHOLD for neighbours, but still see if they were success nodes.