### PR TITLE
Add cpctplusdyndist recoverer.

### DIFF
--- a/src/lib/cpctplus.rs
+++ b/src/lib/cpctplus.rs
@@ -124,7 +124,7 @@ impl PartialEq for PathFNode {
     }
 }
 
-struct Corchuelo<'a, TokId: PrimInt + Unsigned> where TokId: 'a {
+struct CPCTPlus<'a, TokId: PrimInt + Unsigned> where TokId: 'a {
     parser: &'a Parser<'a, TokId>
 }
 
@@ -132,10 +132,10 @@ pub(crate) fn recoverer<'a, TokId: PrimInt + Unsigned>
                        (parser: &'a Parser<TokId>)
                      -> Box<Recoverer<TokId> + 'a>
 {
-    Box::new(Corchuelo{parser})
+    Box::new(CPCTPlus{parser})
 }
 
-impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
+impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlus<'a, TokId>
 
 {
     fn recover(&self,
@@ -264,7 +264,7 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for Corchuelo<'a, TokId>
     }
 }
 
-impl<'a, TokId: PrimInt + Unsigned> Corchuelo<'a, TokId> {
+impl<'a, TokId: PrimInt + Unsigned> CPCTPlus<'a, TokId> {
     fn insert(&self,
              n: &PathFNode,
              nbrs: &mut Vec<(u32, PathFNode)>)
@@ -590,7 +590,7 @@ E : 'N'
 ";
 
         let us = "(nn";
-        let (grm, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, us);
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, us);
         let (pt, errs) = pr.unwrap_err();
         let pp = pt.unwrap().pp(&grm, us);
         // Note that:
@@ -634,7 +634,7 @@ E : 'N'
                                 "Insert \"CLOSE_BRACKET\", Delete",
                                 "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\""]);
 
-        let (grm, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, "n)+n+n+n)");
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "n)+n+n+n)");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_all_repairs(&grm,
@@ -644,7 +644,7 @@ E : 'N'
                           errs[1].repairs(),
                           &vec!["Delete"]);
 
-        let (grm, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, "(((+n)+n+n+n)");
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "(((+n)+n+n+n)");
         let (_, errs) = pr.unwrap_err();
         assert_eq!(errs.len(), 2);
         check_all_repairs(&grm,
@@ -675,7 +675,7 @@ U: 'd';
 ";
 
         let us = "";
-        let (grm, pr) = do_parse(RecoveryKind::Corchuelo, &lexs, &grms, &us);
+        let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, &us);
         let (_, errs) = pr.unwrap_err();
         check_all_repairs(&grm,
                           errs[0].repairs(),

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -42,7 +42,7 @@ extern crate test;
 extern crate vob;
 
 mod astar;
-mod corchuelo;
+mod cpctplus;
 pub mod parser;
 pub use parser::{ParseRepair, RecoveryKind};
 mod mf;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -43,6 +43,7 @@ extern crate vob;
 
 mod astar;
 mod cpctplus;
+mod cpctplusdyndist;
 pub mod parser;
 pub use parser::{ParseRepair, RecoveryKind};
 mod mf;

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -41,6 +41,7 @@ use num_traits::{PrimInt, Unsigned};
 
 use mf;
 use cpctplus;
+use cpctplusdyndist;
 
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
@@ -168,6 +169,8 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
                                              RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
+                                             RecoveryKind::CPCTPlusDynDist =>
+                                                cpctplusdyndist::recoverer(self),
                                              RecoveryKind::MF => mf::recoverer(self),
                                              RecoveryKind::None => {
                                                 let la_lexeme = self.next_lexeme(la_idx);
@@ -315,6 +318,7 @@ pub trait Recoverer<TokId: PrimInt + Unsigned> {
 
 pub enum RecoveryKind {
     CPCTPlus,
+    CPCTPlusDynDist,
     MF,
     None
 }

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -40,7 +40,7 @@ use lrtable::{Action, StateGraph, StateTable, StIdx};
 use num_traits::{PrimInt, Unsigned};
 
 use mf;
-use corchuelo;
+use cpctplus;
 
 const RECOVERY_TIME_BUDGET: u64 = 500; // milliseconds
 
@@ -167,7 +167,7 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
                 None => {
                     if recoverer.is_none() {
                         recoverer = Some(match self.rcvry_kind {
-                                             RecoveryKind::Corchuelo => corchuelo::recoverer(self),
+                                             RecoveryKind::CPCTPlus => cpctplus::recoverer(self),
                                              RecoveryKind::MF => mf::recoverer(self),
                                              RecoveryKind::None => {
                                                 let la_lexeme = self.next_lexeme(la_idx);
@@ -314,7 +314,7 @@ pub trait Recoverer<TokId: PrimInt + Unsigned> {
 }
 
 pub enum RecoveryKind {
-    Corchuelo,
+    CPCTPlus,
     MF,
     None
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn usage(prog: &str, msg: &str) -> ! {
         writeln!(&mut stderr(), "{}", msg).ok();
     }
     writeln!(&mut stderr(),
-             "Usage: {} [-r <cpctplus|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
+             "Usage: {} [-r <cpctplus|cpctplusdyndist|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
              leaf).ok();
     process::exit(1);
 }
@@ -84,7 +84,7 @@ fn main() {
                                 .optflag("h", "help", "")
                                 .optopt("r", "recoverer",
                                         "Recoverer to be used (default: mf)",
-                                        "cpctplus|mf|none")
+                                        "cpctplus|cpctplusdyndist|mf|none")
                                 .optopt("y", "yaccvariant",
                                         "Yacc variant to be parsed (default: Original)",
                                         "Original|Eco")
@@ -102,6 +102,7 @@ fn main() {
         Some(s) => {
             match &*s.to_lowercase() {
                 "cpctplus" => RecoveryKind::CPCTPlus,
+                "cpctplusdyndist" => RecoveryKind::CPCTPlusDynDist,
                 "mf" => RecoveryKind::MF,
                 "none" => RecoveryKind::None,
                 _ => usage(prog, &format!("Unknown recoverer '{}'.", s))

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn usage(prog: &str, msg: &str) -> ! {
         writeln!(&mut stderr(), "{}", msg).ok();
     }
     writeln!(&mut stderr(),
-             "Usage: {} [-r <corchuelo|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
+             "Usage: {} [-r <cpctplus|mf|none>] [-y <eco|original>] <lexer.l> <parser.y> <input file>",
              leaf).ok();
     process::exit(1);
 }
@@ -83,8 +83,8 @@ fn main() {
     let matches = match Options::new()
                                 .optflag("h", "help", "")
                                 .optopt("r", "recoverer",
-                                        "Recoverer to be used (default: MF)",
-                                        "Corchuelo|MF|None")
+                                        "Recoverer to be used (default: mf)",
+                                        "cpctplus|mf|none")
                                 .optopt("y", "yaccvariant",
                                         "Yacc variant to be parsed (default: Original)",
                                         "Original|Eco")
@@ -101,7 +101,7 @@ fn main() {
         None => RecoveryKind::MF,
         Some(s) => {
             match &*s.to_lowercase() {
-                "corchuelo" => RecoveryKind::Corchuelo,
+                "cpctplus" => RecoveryKind::CPCTPlus,
                 "mf" => RecoveryKind::MF,
                 "none" => RecoveryKind::None,
                 _ => usage(prog, &format!("Unknown recoverer '{}'.", s))


### PR DESCRIPTION
This PR does two things: first it renames the "corchuelo" recoverer to "cpctplus" to match the paper. Second, it adds a new recoverer "CPCTPlusDynDist" (not a snappy name, I admit) which is a mix of cpctplus and MF: it uses dyn_dist to speed up cpctplus. My quick experiments suggest that CPCTPlusDynDist is quite a bit faster than CPCTPlus, but still a bit slower than MF.

The `cpctplusdyndist.rs` file is, basically, a copy of `mf.rs` (minus the `Dist` struct) with the reduction rules taken from `cpctplus.rs` with the addition of the `dyn_dist` calls. It's less scary than it looks (I hope).