### PR TITLE
Faster ranking

### DIFF
--- a/src/lib/cpctplus.rs
+++ b/src/lib/cpctplus.rs
@@ -141,7 +141,7 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlus<'a, TokId>
                finish_by: Instant,
                parser: &Parser<TokId>,
                in_la_idx: usize,
-               in_pstack: &mut Vec<StIdx>,
+               mut in_pstack: &mut Vec<StIdx>,
                mut tstack: &mut Vec<Node<TokId>>)
            -> (usize, Vec<Vec<ParseRepair>>)
     {
@@ -162,8 +162,8 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlus<'a, TokId>
         // ambiguity, it fires up non-LL sub-parsers, which then tell the LL parser which path it
         // should take).
         let mut start_cactus_pstack = Cactus::new();
-        for st in in_pstack.drain(..) {
-            start_cactus_pstack = start_cactus_pstack.child(st);
+        for st in in_pstack.iter() {
+            start_cactus_pstack = start_cactus_pstack.child(*st);
         }
 
         let start_node = PathFNode{pstack: start_cactus_pstack.clone(),
@@ -242,23 +242,13 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlus<'a, TokId>
         let rnk_rprs = rank_cnds(parser,
                                  finish_by,
                                  in_la_idx,
-                                 &start_cactus_pstack,
+                                 &in_pstack,
                                  smpl_rprs);
-        let (la_idx, mut rpr_pstack) = apply_repairs(parser,
-                                                     in_la_idx,
-                                                     start_cactus_pstack,
-                                                     &mut Some(&mut tstack),
-                                                     &rnk_rprs[0]);
-
-        in_pstack.clear();
-        while !rpr_pstack.is_empty() {
-            let p = rpr_pstack.parent().unwrap();
-            in_pstack.push(rpr_pstack.try_unwrap()
-                                     .unwrap_or_else(|c| *c.val()
-                                                           .unwrap()));
-            rpr_pstack = p;
-        }
-        in_pstack.reverse();
+        let la_idx = apply_repairs(parser,
+                                   in_la_idx,
+                                   &mut in_pstack,
+                                   &mut Some(&mut tstack),
+                                   &rnk_rprs[0]);
 
         (la_idx, rnk_rprs)
     }

--- a/src/lib/cpctplus.rs
+++ b/src/lib/cpctplus.rs
@@ -42,11 +42,10 @@ use lrtable::{Action, StIdx};
 use num_traits::{PrimInt, Unsigned};
 
 use astar::dijkstra;
-use mf::apply_repairs;
+use mf::{apply_repairs, rank_cnds};
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
-const TRY_PARSE_AT_MOST: usize = 250;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Repair {
@@ -240,10 +239,11 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlus<'a, TokId>
 
         let full_rprs = self.collect_repairs(astar_cnds);
         let smpl_rprs = self.simplify_repairs(full_rprs);
-        let rnk_rprs = self.rank_cnds(finish_by,
-                                      in_la_idx,
-                                      &start_cactus_pstack,
-                                      smpl_rprs);
+        let rnk_rprs = rank_cnds(parser,
+                                 finish_by,
+                                 in_la_idx,
+                                 &start_cactus_pstack,
+                                 smpl_rprs);
         let (la_idx, mut rpr_pstack) = apply_repairs(parser,
                                                      in_la_idx,
                                                      start_cactus_pstack,
@@ -442,84 +442,6 @@ impl<'a, TokId: PrimInt + Unsigned> CPCTPlus<'a, TokId> {
                                })
                           .collect())
                       .collect()
-    }
-
-    /// Convert `PathFNode` candidates in `cnds` into vectors of `ParseRepairs`s and rank them (from
-    /// highest to lowest) by the distance they allow parsing to continue without error. If two or more
-    /// `ParseRepair`s allow the same distance of parsing, then the `ParseRepair` which requires
-    /// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
-    /// ordering is non-deterministic.
-    fn rank_cnds(&self,
-                 finish_by: Instant,
-                 in_la_idx: usize,
-                 start_pstack: &Cactus<StIdx>,
-                 in_cnds: Vec<Vec<ParseRepair>>)
-              -> Vec<Vec<ParseRepair>>
-    {
-        let mut cnds = in_cnds.into_iter()
-                              .map(|rprs| {
-                                   let (la_idx, pstack) = apply_repairs(self.parser,
-                                                                        in_la_idx,
-                                                                        start_pstack.clone(),
-                                                                        &mut None,
-                                                                        &rprs);
-                                   (pstack, la_idx, rprs)
-                               })
-                              .collect::<Vec<(Cactus<StIdx>, usize, Vec<ParseRepair>)>>();
-
-        // First try parsing each candidate repair until it hits an error or exceeds TRY_PARSE_AT_MOST
-        // lexemes.
-
-        let mut todo = Vec::new();
-        todo.resize(cnds.len(), true);
-        let mut remng = cnds.len(); // Remaining items in todo
-        let mut i = 0;
-        'b: while i < TRY_PARSE_AT_MOST && remng > 1 {
-            let mut j = 0;
-            while j < todo.len() {
-                if Instant::now() >= finish_by {
-                   break 'b;
-                }
-
-                if !todo[j] {
-                    j += 1;
-                    continue;
-                }
-                let cnd = &mut cnds[j];
-                if cnd.1 > in_la_idx + i {
-                    j += 1;
-                    continue;
-                }
-                let (new_la_idx, new_pstack) = self.parser.lr_cactus(None,
-                                                                     in_la_idx + i,
-                                                                     in_la_idx + i + 1,
-                                                                     cnd.0.clone(),
-                                                                     &mut None);
-                if new_la_idx == in_la_idx + i {
-                    todo[j] = false;
-                    remng -= 1;
-                } else {
-                    cnd.0 = new_pstack;
-                    cnd.1 += 1;
-                }
-                j += 1;
-            }
-            i += 1;
-        }
-
-        // Now rank the candidates into descending order, first by how far they are able to parse, then
-        // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
-        // intuition that "repairs which affect the shortest part of the string are preferable").
-        cnds.sort_unstable_by(|x, y| {
-            y.1.cmp(&x.1)
-               .then_with(|| x.2.len()
-                                .cmp(&y.2.len()))
-               .then_with(|| x.2.cmp(&y.2))
-        });
-
-        cnds.into_iter()
-            .map(|x| x.2)
-            .collect::<Vec<Vec<ParseRepair>>>()
     }
 }
 

--- a/src/lib/cpctplusdyndist.rs
+++ b/src/lib/cpctplusdyndist.rs
@@ -30,9 +30,7 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
-use std::iter::FromIterator;
 use std::time::Instant;
 
 use cactus::Cactus;
@@ -42,7 +40,7 @@ use lrtable::{Action, StIdx};
 use num_traits::{PrimInt, Unsigned};
 
 use astar::astar_all;
-use mf::{apply_repairs, Dist, rank_cnds};
+use mf::{apply_repairs, Dist, rank_cnds, simplify_repairs};
 use parser::{Node, Parser, ParseRepair, Recoverer};
 
 const PARSE_AT_LEAST: usize = 3; // N in Corchuelo et al.
@@ -226,12 +224,15 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for CPCTPlusDynDist<'a, Tok
         }
 
         let full_rprs = self.collect_repairs(astar_cnds);
-        let smpl_rprs = self.simplify_repairs(full_rprs);
-        let rnk_rprs = rank_cnds(parser,
-                                 finish_by,
-                                 in_la_idx,
-                                 &in_pstack,
-                                 smpl_rprs);
+        let mut rnk_rprs = rank_cnds(parser,
+                                     finish_by,
+                                     in_la_idx,
+                                     &in_pstack,
+                                     full_rprs);
+        if rnk_rprs.is_empty() {
+            return (in_la_idx, vec![]);
+        }
+        simplify_repairs(&mut rnk_rprs);
         let la_idx = apply_repairs(parser,
                                    in_la_idx,
                                    &mut in_pstack,
@@ -324,7 +325,7 @@ impl<'a, TokId: PrimInt + Unsigned> CPCTPlusDynDist<'a, TokId> {
     }
 
     /// Convert the output from `astar_all` into something more usable.
-    fn collect_repairs(&self, cnds: Vec<PathFNode>) -> Vec<Vec<Repair>>
+    fn collect_repairs(&self, cnds: Vec<PathFNode>) -> Vec<Vec<Vec<ParseRepair>>>
     {
         fn traverse(rm: &Cactus<RepairMerge>) -> Vec<Vec<Repair>> {
             let mut out = Vec::new();
@@ -363,51 +364,26 @@ impl<'a, TokId: PrimInt + Unsigned> CPCTPlusDynDist<'a, TokId> {
 
         let mut all_rprs = Vec::with_capacity(cnds.len());
         for cnd in cnds {
-            all_rprs.extend(traverse(&cnd.repairs));
+            all_rprs.push(traverse(&cnd.repairs).into_iter()
+                                                .map(|x| self.repair_to_parse_repair(x))
+                                                .collect::<Vec<_>>());
         }
         all_rprs
     }
 
-    /// Take an (unordered) set of parse repairs and return a simplified (unordered) set of parse
-    /// repairs. Note that the caller must make no assumptions about the size or contents of the output
-    /// set: this function might delete, expand, or do other things to repairs.
-    fn simplify_repairs(&self,
-                        mut all_rprs: Vec<Vec<Repair>>)
-                     -> Vec<Vec<ParseRepair>>
-    {
-        for i in 0..all_rprs.len() {
-            // Remove shifts from the end of repairs
-            let mut rprs = &mut all_rprs[i];
-            while !rprs.is_empty() {
-                if let Repair::Shift = rprs[rprs.len() - 1] {
-                    rprs.pop();
-                } else {
-                    break;
-                }
-            }
-        }
-
-        // The simplifications above can mean that we now end up with equivalent repairs. Remove
-        // duplicates by creating a temporary HashSet. This is a hack, but since Vec<Repair> isn't
-        // sortable, this is the easiest, and fastet way we have of getting things done.
-        {
-            let tmp: HashSet<Vec<Repair>> = HashSet::from_iter(all_rprs);
-            all_rprs = tmp.into_iter()
-                          .collect::<Vec<Vec<Repair>>>();
-        }
-
-        all_rprs.iter()
-                .map(|x| x.iter()
-                          .map(|y| {
-                                        match *y {
-                                            Repair::InsertTerm(term_idx) =>
-                                                ParseRepair::Insert(term_idx),
-                                            Repair::Delete => ParseRepair::Delete,
-                                            Repair::Shift => ParseRepair::Shift,
-                                        }
-                               })
-                          .collect())
-                      .collect()
+    fn repair_to_parse_repair(&self,
+                              from: Vec<Repair>)
+                           -> Vec<ParseRepair> {
+        from.iter()
+            .map(|y| {
+                 match *y {
+                     Repair::InsertTerm(term_idx) =>
+                         ParseRepair::Insert(term_idx),
+                     Repair::Delete => ParseRepair::Delete,
+                     Repair::Shift => ParseRepair::Shift,
+                 }
+             })
+            .collect()
     }
 
     /// Return the distance from `st_idx` at input position `la_idx`, given the current `repairs`.

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -521,6 +521,7 @@ pub(crate) fn rank_cnds<TokId: PrimInt + Unsigned>
                      -> Vec<Vec<ParseRepair>>
 {
     let mut cnds = Vec::new();
+    let mut furthest = 0;
     for rprs in in_cnds.into_iter() {
         if Instant::now() >= finish_by {
             return vec![];
@@ -536,12 +537,19 @@ pub(crate) fn rank_cnds<TokId: PrimInt + Unsigned>
                                 in_la_idx + TRY_PARSE_AT_MOST,
                                 &mut pstack,
                                 &mut None);
+        if la_idx >= furthest {
+            furthest = la_idx;
+        }
         cnds.push((pstack, la_idx, rprs));
     }
 
-    // Now rank the candidates into descending order, first by how far they are able to parse, then
-    // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
-    // intuition that "repairs which affect the shortest part of the string are preferable").
+    // Remove any elements except those which parsed as far as possible.
+    cnds = cnds.into_iter().filter(|x| x.1 == furthest).collect::<Vec<_>>();
+
+    // Sort the candidates by the number of actions in the repairs (the latter is somewhat
+    // arbitrary, but matches the intuition that "repairs which affect the shortest part of the
+    // string are preferable") and then by the repair itself (so if you have lots of repair
+    // sequences starting "Insert x" they at least end up next to each other in the output).
     cnds.sort_unstable_by(|x, y| {
         y.1.cmp(&x.1)
            .then_with(|| x.2.len()
@@ -1247,7 +1255,6 @@ Factor: 'OPEN_BRACKET' Expr 'CLOSE_BRACKET'
                                 "Insert \"CLOSE_BRACKET\", Delete",
                                 "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\"",
                                 "Insert \"MULT\", Shift, Insert \"CLOSE_BRACKET\""]);
-
 
         let us = "(+++++)";
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, &us);

--- a/src/lib/mf.rs
+++ b/src/lib/mf.rs
@@ -231,10 +231,11 @@ impl<'a, TokId: PrimInt + Unsigned> Recoverer<TokId> for MF<'a, TokId>
 
         let full_rprs = self.collect_repairs(astar_cnds);
         let smpl_rprs = self.simplify_repairs(full_rprs);
-        let rnk_rprs = self.rank_cnds(finish_by,
-                                      in_la_idx,
-                                      &start_cactus_pstack,
-                                      smpl_rprs);
+        let rnk_rprs = rank_cnds(parser,
+                                 finish_by,
+                                 in_la_idx,
+                                 &start_cactus_pstack,
+                                 smpl_rprs);
         let (la_idx, mut rpr_pstack) = apply_repairs(parser,
                                                      in_la_idx,
                                                      start_cactus_pstack,
@@ -356,7 +357,6 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
         }
     }
 
-
     /// Convert the output from `astar_all` into something more usable.
     fn collect_repairs(&self, cnds: Vec<PathFNode>) -> Vec<Vec<Repair>>
     {
@@ -444,84 +444,6 @@ impl<'a, TokId: PrimInt + Unsigned> MF<'a, TokId> {
                       .collect()
     }
 
-    /// Convert `PathFNode` candidates in `cnds` into vectors of `ParseRepairs`s and rank them (from
-    /// highest to lowest) by the distance they allow parsing to continue without error. If two or more
-    /// `ParseRepair`s allow the same distance of parsing, then the `ParseRepair` which requires
-    /// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
-    /// ordering is non-deterministic.
-    fn rank_cnds(&self,
-                 finish_by: Instant,
-                 in_la_idx: usize,
-                 start_pstack: &Cactus<StIdx>,
-                 in_cnds: Vec<Vec<ParseRepair>>)
-              -> Vec<Vec<ParseRepair>>
-    {
-        let mut cnds = in_cnds.into_iter()
-                              .map(|rprs| {
-                                   let (la_idx, pstack) = apply_repairs(self.parser,
-                                                                        in_la_idx,
-                                                                        start_pstack.clone(),
-                                                                        &mut None,
-                                                                        &rprs);
-                                   (pstack, la_idx, rprs)
-                               })
-                              .collect::<Vec<(Cactus<StIdx>, usize, Vec<ParseRepair>)>>();
-
-        // First try parsing each candidate repair until it hits an error or exceeds TRY_PARSE_AT_MOST
-        // lexemes.
-
-        let mut todo = Vec::new();
-        todo.resize(cnds.len(), true);
-        let mut remng = cnds.len(); // Remaining items in todo
-        let mut i = 0;
-        'b: while i < TRY_PARSE_AT_MOST && remng > 1 {
-            let mut j = 0;
-            while j < todo.len() {
-                if Instant::now() >= finish_by {
-                    break 'b;
-                }
-
-                if !todo[j] {
-                    j += 1;
-                    continue;
-                }
-                let cnd = &mut cnds[j];
-                if cnd.1 > in_la_idx + i {
-                    j += 1;
-                    continue;
-                }
-                let (new_la_idx, new_pstack) = self.parser.lr_cactus(None,
-                                                                     in_la_idx + i,
-                                                                     in_la_idx + i + 1,
-                                                                     cnd.0.clone(),
-                                                                     &mut None);
-                if new_la_idx == in_la_idx + i {
-                    todo[j] = false;
-                    remng -= 1;
-                } else {
-                    cnd.0 = new_pstack;
-                    cnd.1 += 1;
-                }
-                j += 1;
-            }
-            i += 1;
-        }
-
-        // Now rank the candidates into descending order, first by how far they are able to parse, then
-        // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
-        // intuition that "repairs which affect the shortest part of the string are preferable").
-        cnds.sort_unstable_by(|x, y| {
-            y.1.cmp(&x.1)
-               .then_with(|| x.2.len()
-                                .cmp(&y.2.len()))
-               .then_with(|| x.2.cmp(&y.2))
-        });
-
-        cnds.into_iter()
-            .map(|x| x.2)
-            .collect::<Vec<Vec<ParseRepair>>>()
-    }
-
     /// Return the distance from `st_idx` at input position `la_idx`, given the current `repairs`.
     /// Returns `None` if no route can be found.
     fn dyn_dist(&self,
@@ -593,6 +515,54 @@ fn ends_with_parse_at_least_shifts(repairs: &Cactus<RepairMerge>) -> bool {
         }
     }
     shfts == PARSE_AT_LEAST
+}
+
+/// Convert `PathFNode` candidates in `cnds` into vectors of `ParseRepairs`s and rank them (from
+/// highest to lowest) by the distance they allow parsing to continue without error. If two or more
+/// `ParseRepair`s allow the same distance of parsing, then the `ParseRepair` which requires
+/// repairs over the shortest distance is preferred. Amongst `ParseRepair`s of the same rank, the
+/// ordering is non-deterministic.
+pub(crate) fn rank_cnds<TokId: PrimInt + Unsigned>
+                       (parser: &Parser<TokId>,
+                        finish_by: Instant,
+                        in_la_idx: usize,
+                        start_pstack: &Cactus<StIdx>,
+                        in_cnds: Vec<Vec<ParseRepair>>)
+                     -> Vec<Vec<ParseRepair>>
+{
+    let mut cnds = Vec::new();
+    for rprs in in_cnds.into_iter() {
+        if Instant::now() >= finish_by {
+            return vec![];
+        }
+        let (la_idx, pstack) = apply_repairs(parser,
+                                             in_la_idx,
+                                             start_pstack.clone(),
+                                             &mut None,
+                                             &rprs);
+        let mut vec_pstack = pstack.vals()
+                                   .cloned()
+                                   .collect::<Vec<_>>();
+        vec_pstack.reverse();
+        let new_la_idx = parser.lr_upto(la_idx,
+                                        in_la_idx + TRY_PARSE_AT_MOST,
+                                        &mut vec_pstack);
+        cnds.push((vec_pstack, new_la_idx, rprs));
+    }
+
+    // Now rank the candidates into descending order, first by how far they are able to parse, then
+    // by the number of actions in the repairs (the latter is somewhat arbitrary, but matches the
+    // intuition that "repairs which affect the shortest part of the string are preferable").
+    cnds.sort_unstable_by(|x, y| {
+        y.1.cmp(&x.1)
+           .then_with(|| x.2.len()
+                            .cmp(&y.2.len()))
+           .then_with(|| x.2.cmp(&y.2))
+    });
+
+    cnds.into_iter()
+        .map(|x| x.2)
+        .collect::<Vec<Vec<ParseRepair>>>()
 }
 
 /// Apply the `repairs` to `pstack` starting at position `la_idx`: return the resulting parse

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -214,25 +214,44 @@ impl<'a, TokId: PrimInt + Unsigned> Parser<'a, TokId> {
     /// the input is < end_la_idx, or if an error is encountered). Does not do any form of error
     /// recovery.
     pub fn lr_upto(&self,
+                   lexeme_prefix: Option<Lexeme<TokId>>,
                    mut la_idx: usize,
                    end_la_idx: usize,
-                   pstack: &mut PStack)
+                   pstack: &mut PStack,
+                   tstack: &mut Option<&mut Vec<Node<TokId>>>)
            -> usize
     {
-        while la_idx < end_la_idx {
+        assert!(lexeme_prefix.is_none() || end_la_idx == la_idx + 1);
+        while la_idx != end_la_idx && la_idx <= self.lexemes.len() {
             let st = *pstack.last().unwrap();
-            let la_tidx = self.next_tidx(la_idx);
+            let la_tidx = if let Some(l) = lexeme_prefix {
+                              TIdx::from(l.tok_id().to_u32().unwrap())
+                          } else {
+                              self.next_tidx(la_idx)
+                          };
 
             match self.stable.action(st, la_tidx) {
                 Some(Action::Reduce(prod_id)) => {
                     let nonterm_idx = self.grm.prod_to_nonterm(prod_id);
                     let pop_idx = pstack.len() - self.grm.prod(prod_id).len();
+                    if let Some(ref mut tstack_uw) = *tstack {
+                        let nodes = tstack_uw.drain(pop_idx - 1..).collect::<Vec<Node<TokId>>>();
+                        tstack_uw.push(Node::Nonterm{nonterm_idx: nonterm_idx, nodes: nodes});
+                    }
 
                     pstack.drain(pop_idx..);
                     let prior = *pstack.last().unwrap();
                     pstack.push(self.stable.goto(prior, nonterm_idx).unwrap());
                 },
                 Some(Action::Shift(state_id)) => {
+                    if let Some(ref mut tstack_uw) = *tstack {
+                        let la_lexeme = if let Some(l) = lexeme_prefix {
+                                            l
+                                        } else {
+                                            self.next_lexeme(la_idx)
+                                        };
+                        tstack_uw.push(Node::Term{lexeme: la_lexeme});
+                    }
                     pstack.push(state_id);
                     la_idx += 1;
                 },


### PR DESCRIPTION
These are changes that I've been meaning to do for ages: they basically speed the bit *after* finding repairs up. This is nearly always faster, but small examples are so quick that it's irrelevant either way. However, for nasty examples like:

```java
  class D {
    int x = f(""x""y);
  }
```

this can make a useful difference. This particular example generates 23,067 repair sequences (really!); on this branch (which admittedly contains other changes) it runs about 15% faster (which is equivalent to about 0.1s in this case i.e. enough to be useful).

Each commit is self contained and probably best reviewed separately.