### PR TITLE
Reflect lrlex changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: rust
-rust: nightly-2018-03-25
+rust: nightly
 

--- a/src/lib/cpctplus.rs
+++ b/src/lib/cpctplus.rs
@@ -464,16 +464,16 @@ mod test {
     fn corchuelo_example() {
         // The example from the Curchuelo paper
         let lexs = "%%
-[(] OPEN_BRACKET
-[)] CLOSE_BRACKET
-[+] PLUS
-n N
+\\( '('
+\\) ')'
+\\+ '+'
+n 'N'
 ";
         let grms = "%start E
 %%
 E : 'N'
-  | E 'PLUS' 'N'
-  | 'OPEN_BRACKET' E 'CLOSE_BRACKET'
+  | E '+' 'N'
+  | '(' E ')'
   ;
 ";
 
@@ -483,29 +483,29 @@ E : 'N'
         let pp = pt.unwrap().pp(&grm, us);
         // Note that:
         //   E
-        //    OPEN_BRACKET (
+        //    ( (
         //    E
         //     E
         //      N n
-        //     PLUS 
+        //     + 
         //     N n
-        //    CLOSE_BRACKET 
+        //    )
         // is also the result of a valid minimal-cost repair, but, since the repair involves a
         // Shift, rank_cnds will always put this too low down the list for us to ever see it.
         if !vec![
 "E
- OPEN_BRACKET (
+ ( (
  E
   N n
- CLOSE_BRACKET 
+ ) 
 ",
 "E
  E
-  OPEN_BRACKET (
+  ( (
   E
    N n
-  CLOSE_BRACKET 
- PLUS 
+  ) 
+ + 
  N n
 "]
             .iter()
@@ -518,9 +518,9 @@ E : 'N'
         assert_eq!(errs[0].lexeme(), &Lexeme::new(err_tok_id, 2, 1));
         check_all_repairs(&grm,
                           errs[0].repairs(),
-                          &vec!["Insert \"CLOSE_BRACKET\", Insert \"PLUS\"",
-                                "Insert \"CLOSE_BRACKET\", Delete",
-                                "Insert \"PLUS\", Shift, Insert \"CLOSE_BRACKET\""]);
+                          &vec!["Insert \")\", Insert \"+\"",
+                                "Insert \")\", Delete",
+                                "Insert \"+\", Shift, Insert \")\""]);
 
         let (grm, pr) = do_parse(RecoveryKind::CPCTPlus, &lexs, &grms, "n)+n+n+n)");
         let (_, errs) = pr.unwrap_err();
@@ -541,16 +541,16 @@ E : 'N'
                                 "Delete"]);
         check_all_repairs(&grm,
                           errs[1].repairs(),
-                          &vec!["Insert \"CLOSE_BRACKET\""]);
+                          &vec!["Insert \")\""]);
     }
 
     #[test]
     fn test_merge() {
         let lexs = "%%
-a a
-b b
-c c
-d d
+a 'a'
+b 'b'
+c 'c'
+d 'd'
 ";
 
         let grms = "%start S

--- a/src/lib/parser.rs
+++ b/src/lib/parser.rs
@@ -510,12 +510,12 @@ pub(crate) mod test {
     fn simple_parse() {
         // From p4 of https://www.cs.umd.edu/class/spring2014/cmsc430/lectures/lec07.pdf
         check_parse_output("%%
-[a-zA-Z_] ID
-[+] PLUS",
+[a-zA-Z_] 'ID'
+\\+ '+'",
 "
 %start E
 %%
-E: T 'PLUS' E
+E: T '+' E
  | T;
 T: 'ID';
 ",
@@ -523,7 +523,7 @@ T: 'ID';
 "E
  T
   ID a
- PLUS +
+ + +
  E
   T
    ID b
@@ -533,7 +533,7 @@ T: 'ID';
     #[test]
     fn parse_empty_rules() {
         let lexs = "%%
-[a-zA-Z_] ID";
+[a-zA-Z_] 'ID'";
         let grms = "%start S
 %%
 S: L;
@@ -555,14 +555,14 @@ L: 'ID'
     #[test]
     fn recursive_parse() {
         let lexs = "%%
-[+] PLUS
-[*] MULT
-[0-9]+ INT
+\\+ '+'
+\\* '*'
+[0-9]+ 'INT'
 ";
         let grms = "%start Expr
 %%
-Expr : Term 'PLUS' Expr | Term;
-Term : Factor 'MULT' Term | Factor;
+Expr : Term '+' Expr | Term;
+Term : Factor '*' Term | Factor;
 Factor : 'INT';";
 
         check_parse_output(&lexs, &grms, "2+3*4",
@@ -570,12 +570,12 @@ Factor : 'INT';";
  Term
   Factor
    INT 2
- PLUS +
+ + +
  Expr
   Term
    Factor
     INT 3
-   MULT *
+   * *
    Term
     Factor
      INT 4
@@ -585,11 +585,11 @@ Factor : 'INT';";
  Term
   Factor
    INT 2
-  MULT *
+  * *
   Term
    Factor
     INT 3
- PLUS +
+ + +
  Expr
   Term
    Factor
@@ -600,19 +600,19 @@ Factor : 'INT';";
     #[test]
     fn parse_error() {
         let lexs = "%%
-[(] OPEN_BRACKET
-[)] CLOSE_BRACKET
-[a-zA-Z_][a-zA-Z_0-9]* ID
+\\( '('
+\\) ')'
+[a-zA-Z_][a-zA-Z_0-9]* 'ID'
 ";
         let grms = "%start Call
 %%
-Call: 'ID' 'OPEN_BRACKET' 'CLOSE_BRACKET';";
+Call: 'ID' '(' ')';";
 
         check_parse_output(&lexs, &grms, "f()",
 "Call
  ID f
- OPEN_BRACKET (
- CLOSE_BRACKET )
+ ( (
+ ) )
 ");
 
         let (grm, pr) = do_parse(RecoveryKind::MF, &lexs, &grms, "f(");


### PR DESCRIPTION
As of #4e518d6bc, rule identifiers have to be quoted. No functional change (though I've taken use of the situation to change things like `CLOSE_BRACKET` into the much more obvious `)`).