### PR TITLE
A basic compile-time system for generating parsers statically.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: rust
 rust: nightly
-
+script:
+    - cargo test
+    - cd examples calc && cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ path = "src/lib/mod.rs"
 
 [dependencies]
 cactus = "1.0"
-cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
+cfgrammar = { git="https://github.com/softdevteam/cfgrammar", features=["serde"] }
 getopts = "0.2"
 indexmap = "1.0"
-lrlex = { git = "http://github.com/softdevteam/lrlex" }
-lrtable = { git = "http://github.com/softdevteam/lrtable" }
+lrlex = { git="https://github.com/softdevteam/lrlex" }
+lrtable = { git="https://github.com/softdevteam/lrtable", features=["serde"] }
 num-traits = "0.2"
+rmp-serde = "0.13"
+serde = { version="1.0", features=["derive"] }
+typename = "0.1"
 vob = "1.3"
 
 [profile.release]

--- a/examples/calc/Cargo.toml
+++ b/examples/calc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "calc"
+version = "0.1.0"
+authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+
+[[bin]]
+doc = false
+name = "calc"
+
+[build-dependencies]
+lrlex = { git="http://github.com/softdevteam/lrlex" }
+lrpar = { path="../.." }
+
+[dependencies]
+lrlex = { git="http://github.com/softdevteam/lrlex" }
+lrpar = { path="../.." }

--- a/examples/calc/README.md
+++ b/examples/calc/README.md
@@ -1,0 +1,10 @@
+# Parsing a simple calculator language
+
+This directory contains a very simple example of a calculator in `lrpar`.
+Executing `cargo run` processes `src/calc.l` and `src/calc.y` at compile-time;
+the resulting binary then takes input from stdin. You can type anything in here
+(though you'll only get useful output for valid input!) -- parsing and lexing
+errors are reported.
+
+Look at `build.rs`, `src/calc.y`, and `src/main.rs` to see how to use `lrpar` in
+your project.

--- a/examples/calc/build.rs
+++ b/examples/calc/build.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 King's College London
+// Copyright (c) 2018 King's College London
 // created by the Software Development Team <http://soft-dev.org/>
 //
 // The Universal Permissive License (UPL), Version 1.0
@@ -30,36 +30,16 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![feature(test)]
-#![feature(try_from)]
-
-extern crate cactus;
-extern crate cfgrammar;
-#[macro_use] extern crate indexmap;
 extern crate lrlex;
-extern crate lrtable;
-extern crate num_traits;
-extern crate rmp_serde as rmps;
-extern crate serde;
-extern crate test;
-extern crate typename;
-extern crate vob;
+extern crate lrpar;
 
-mod astar;
-mod builder;
-mod cpctplus;
-pub mod parser;
-pub use parser::{Node, parse_rcvry, ParseError, ParseRepair, RecoveryKind};
-mod mf;
+fn main() {
+    // First we create the parser, which returns a HashMap of all the tokens used, then we pass
+    // that HashMap to the lexer.
 
-pub use builder::{process_file, process_file_in_src, reconstitute};
-
-/// A convenience macro for including statically compiled `.y` files. A file `src/x.y` which is
-/// statically compiled by lrpar can then be used in a crate with `lrpar_mod!(x)`.
-#[macro_export]
-macro_rules! lrpar_mod {
-    ($n:ident) => { include!(concat!(env!("OUT_DIR"), "/", stringify!($n), ".rs")); };
+    // Note that we specify the integer type (u8) we'll use for token IDs (this type *must* be big
+    // enough to fit all IDs in) as well as the input file (which must end in ".y" for lrpar, and
+    // ".l" for lrlex).
+    let lex_rule_ids_map = lrpar::process_file_in_src::<u8>("calc.y").unwrap();
+    lrlex::process_file_in_src::<u8>("calc.l", Some(lex_rule_ids_map)).unwrap();
 }
-
-#[doc(hidden)]
-pub use cfgrammar::NTIdx;

--- a/examples/calc/src/calc.l
+++ b/examples/calc/src/calc.l
@@ -1,0 +1,7 @@
+%%
+[0-9]+ "INT"
+\+ "PLUS"
+\* "MUL"
+\( "LBRACK"
+\( "RBRACK"
+[\t ]+ ;

--- a/examples/calc/src/calc.y
+++ b/examples/calc/src/calc.y
@@ -1,0 +1,10 @@
+%start Expr
+%%
+Expr: Term 'PLUS' Expr
+    | Term ;
+
+Term: Factor 'MUL' Term
+    | Factor ;
+
+Factor: 'LBRACK' Expr 'RBRACK'
+      | 'INT' ;

--- a/examples/calc/src/main.rs
+++ b/examples/calc/src/main.rs
@@ -1,0 +1,47 @@
+use std::io::{self, BufRead, Write};
+
+#[macro_use] extern crate lrlex;
+#[macro_use] extern crate lrpar;
+
+// Using `lrlex_mod!` brings the lexer for `calc.l` into scope.
+lrlex_mod!(calc_l);
+// Using `lrpar_mod!` brings the lexer for `calc.l` into scope.
+lrpar_mod!(calc_y);
+
+fn main() {
+    // We need to get a `LexerDef` for the `calc` language in order that we can lex input.
+    let lexerdef = calc_l::lexerdef();
+    let stdin = io::stdin();
+    loop {
+        print!(">>> ");
+        io::stdout().flush().ok();
+        match stdin.lock().lines().next() {
+            Some(Ok(ref l)) => {
+                if l.trim().is_empty() {
+                    continue;
+                }
+                // Now we create a lexer with the `lexer` method with which we can lex an input.
+                // Note that each lexer can only lex one input in its lifetime.
+                let lexer = lexerdef.lexer(l);
+                match lexer.lexemes() {
+                    Ok(lexemes) => {
+                        // Now parse the stream of lexemes into a tree
+                        match calc_y::parse(&lexemes) {
+                            Ok(pt) => println!("{:?}", pt),
+                            Err((_, errs)) => {
+                                // One or more errors were detected during parsing.
+                                for e in errs {
+                                    let (line, col) = lexer.line_and_col(e.lexeme()).unwrap();
+                                    assert_eq!(line, 1);
+                                    println!("Error at column {}.", col);
+                                }
+                            }
+                        }
+                    },
+                    Err(e) => println!("Lexing error {:?}", e)
+                }
+            },
+            _ => break
+        }
+    }
+}

--- a/src/lib/builder.rs
+++ b/src/lib/builder.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::HashMap;
+use std::convert::{AsRef, TryFrom};
+use std::env::{current_dir, var};
+use std::error::Error;
+use std::fmt::Debug;
+use std::fs::{File, read_to_string};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use cfgrammar::yacc::{yacc_grm, YaccGrammar, YaccKind};
+use lrtable::{Minimiser, from_yacc, StateGraph, StateTable};
+use rmps::{Deserializer, Serializer};
+use serde::{Deserialize, Serialize};
+use typename::TypeName;
+
+const YACC_SUFFIX: &str = "_y";
+const YACC_FILE_EXT: &str = "y";
+const RUST_FILE_EXT: &str = "rs";
+
+/// Given the filename `x.y` as input, it will statically compile the file `src/x.y` into a Rust
+/// module which can then be imported using `lrpar_mod!(x_y)`. This is a convenience function
+/// around [`process_file`](fn.process_file.html) which makes it easier to compile `.y` files
+/// stored in a project's `src/` directory. Note that leaf names must be unique within a single
+/// project, even if they are in different directories: in other words, `a.y` and `x/a.y` will both
+/// be mapped to the same module `a_y` (and it is undefined what the resulting Rust module will
+/// contain).
+///
+/// # Panics
+///
+/// If the input filename does not end in `.y`.
+pub fn process_file_in_src<TokId>(srcp: &str)
+                               -> Result<(HashMap<String, TokId>), Box<Error>>
+                            where TokId: Copy + Debug + Eq + TryFrom<usize> + TypeName
+{
+    let mut inp = current_dir()?;
+    inp.push("src");
+    inp.push(srcp);
+    if Path::new(srcp).extension().unwrap().to_str().unwrap() != YACC_FILE_EXT {
+        panic!("File name passed to process_file_in_src must have extension '{}'.", YACC_FILE_EXT);
+    }
+    let mut leaf = inp.file_stem().unwrap().to_str().unwrap().to_owned();
+    leaf.push_str(&YACC_SUFFIX);
+    let mut outp = PathBuf::new();
+    outp.push(var("OUT_DIR").unwrap());
+    outp.push(leaf);
+    outp.set_extension(RUST_FILE_EXT);
+    process_file::<TokId, _, _>(inp, outp)
+}
+
+/// Statically compile the `.y` file `inp` into Rust, placing the output into `outp`. The latter
+/// defines a module with the following function:
+/// ```rust,ignore
+///      parser(lexemes: &Vec<Lexeme<TokId>>)
+///   -> Result<Node<TokId>,
+///            (Option<Node<TokId>>, Vec<ParseError<TokId>>)>
+/// ```
+pub fn process_file<'a, TokId, P, Q>(inp: P,
+                                     outp: Q)
+                                  -> Result<(HashMap<String, TokId>), Box<Error>>
+                               where TokId: Copy + Debug + Eq + TryFrom<usize> + TypeName,
+                                     P: AsRef<Path>,
+                                     Q: AsRef<Path>
+{
+    let inc = read_to_string(&inp).unwrap();
+
+    let grm = match yacc_grm(YaccKind::Eco, &inc) {
+        Ok(x) => x,
+        Err(s) => {
+            panic!("{:?}", s);
+        }
+    };
+    let rule_ids = grm.terms_map().iter()
+                                  .map(|(&n, &i)| (n.to_owned(),
+                                                   TokId::try_from(usize::from(i))
+                                                         .unwrap_or_else(|_| panic!("woo"))))
+                                  .collect::<HashMap<_, _>>();
+
+    let (sgraph, stable) = match from_yacc(&grm, Minimiser::Pager) {
+        Ok(x) => x,
+        Err(s) => {
+            panic!("{:?}", s);
+        }
+    };
+
+    let mut outs = String::new();
+    // Header
+    let mod_name = inp.as_ref().file_stem().unwrap().to_str().unwrap();
+    outs.push_str(&format!("mod {}_y {{", mod_name));
+    outs.push_str(&format!("use lrpar::{{Node, parse_rcvry, ParseError, reconstitute, RecoveryKind}};
+use lrlex::Lexeme;
+
+pub fn parse(lexemes: &Vec<Lexeme<{tn}>>)
+          -> Result<Node<{tn}>, (Option<Node<{tn}>>, Vec<ParseError<{tn}>>)>
+{{", tn=TokId::type_name()));
+
+    // grm, sgraph, stable
+    let mut grm_buf = Vec::new();
+    grm.serialize(&mut Serializer::new(&mut grm_buf)).unwrap();
+    let mut sgraph_buf = Vec::new();
+    sgraph.serialize(&mut Serializer::new(&mut sgraph_buf)).unwrap();
+    let mut stable_buf = Vec::new();
+    stable.serialize(&mut Serializer::new(&mut stable_buf)).unwrap();
+    outs.push_str(&format!("
+    let (grm, sgraph, stable) = reconstitute(&vec!{:?}, &vec!{:?}, &vec!{:?});
+    parse_rcvry(RecoveryKind::MF, &grm, |_| 1, &sgraph, &stable, lexemes)
+", grm_buf, sgraph_buf, stable_buf));
+
+    outs.push_str("}");
+
+    // Footer
+    outs.push_str("}");
+    // If the file we're about to write out already exists with the same contents, then we don't
+    // overwrite it (since that will force a recompile of the file, and relinking of the binary
+    // etc).
+    if let Ok(curs) = read_to_string(&outp) {
+        if curs == outs {
+            return Ok(rule_ids);
+        }
+    }
+    let mut f = File::create(outp)?;
+    f.write_all(outs.as_bytes())?;
+    Ok(rule_ids)
+}
+
+/// This function is called by generated files; it exists so that generated files don't require a
+/// dependency on serde and rmps.
+#[doc(hidden)]
+pub fn reconstitute(grm_buf: &[u8], sgraph_buf: &[u8], stable_buf: &[u8])
+                -> (YaccGrammar, StateGraph, StateTable)
+{
+    let mut grm_de = Deserializer::new(&grm_buf[..]);
+    let grm = Deserialize::deserialize(&mut grm_de).unwrap();
+    let mut sgraph_de = Deserializer::new(&sgraph_buf[..]);
+    let sgraph = Deserialize::deserialize(&mut sgraph_de).unwrap();
+    let mut stable_de = Deserializer::new(&stable_buf[..]);
+    let stable = Deserialize::deserialize(&mut stable_de).unwrap();
+    (grm, sgraph, stable)
+}


### PR DESCRIPTION
This is similar in use to the compile-time system for lrlex, though the implementation details are very different. For simplicity, we use serde to serialize the grammar, state graph, and state table at compile-time, loading them back in later.

There is one major missing feature which is that there is no way to get NDIdxs. We don't currently provide access to the Grammar struct, nor do we provide compile-time constants. I need to think more about how to do this, possibly changing the way that NTIdx is defined in cfgrammar. However, that can be done later: the bare bones here are, I think, sufficient to see clearly the direction
of travel.